### PR TITLE
Add c rtcm decoder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build*/
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 build*/
 .idea/
+c/cmake-build-debug/
+cmake-build-debug/

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,4 +38,4 @@ install:
   - (cd haskell && stack build --only-dependencies)
 
 script:
-  - (cd ./c && mkdir ./build && cd ./build && cmake ../ && make -j4 && cd ../../haskell && stack build --test)
+  - bash ./travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-sudo: false
+sudo: required
+dist: trusty
 
 language: c
 
@@ -21,6 +22,15 @@ before_install:
   - export PATH=~/.local/bin:$PATH
   - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/.local/lib
   - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+  # Travis' version of CMake is too old for some reason, and the only
+  # PPA for Ubuntu trusty disappeared sometime around 3 October 2016.
+  # So instead, we install a reasonably recent version from a PPA for
+  # Ubuntu precise, and we have to do it manually, because
+  # apt-add-repository can't use other system specifiers.
+  - echo 'deb http://ppa.launchpad.net/george-edison55/precise-backports/ubuntu precise main' | sudo tee /etc/apt/sources.list.d/cmake.list
+  - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 084ECFC5828AB726
+  - sudo apt-get update
+  - sudo apt-get install cmake
 
 install:
   - (cd haskell && stack update)
@@ -28,4 +38,4 @@ install:
   - (cd haskell && stack build --only-dependencies)
 
 script:
-  - (cd haskell && stack build --test)
+  - (cd ./c && mkdir ./build && cd ./build && cmake ../ && make -j4 && cd ../../haskell && stack build --test)

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,11 @@ language: c
 
 addons:
   apt:
+    sources:
+      - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.8 main'
+        key_url: 'http://apt.llvm.org/llvm-snapshot.gpg.key'
     packages:
-    - libgmp-dev
+      - libgmp-dev
 
 cache:
   apt: true

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 2.8.7)
+project(librtcm)
+
+add_subdirectory (src)
+add_subdirectory (test)

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 2.8.7)
 project(librtcm)
 
+# Some compiler options used globally
+set(CMAKE_C_FLAGS "-Wall -Wextra -Wno-strict-prototypes -Werror -std=gnu99 -fno-unwind-tables -fno-asynchronous-unwind-tables -Wimplicit -Wshadow -Wswitch-default -Wswitch-enum -Wundef -Wuninitialized -Wpointer-arith -Wstrict-prototypes -Wcast-align -Wformat=2 -Wimplicit-function-declaration -Wredundant-decls -Wformat-security ${CMAKE_C_FLAGS}")
+
+
 add_subdirectory (src)
 add_subdirectory (test)

--- a/c/include/common.h
+++ b/c/include/common.h
@@ -1,0 +1,28 @@
+//
+// Created by Anthony Cole on 6/26/17.
+//
+
+#ifndef LIBRTCM_COMMON_H
+#define LIBRTCM_COMMON_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+/** Signed 8-bit integer. */
+typedef int8_t s8;
+/** Signed 16-bit integer. */
+typedef int16_t s16;
+/** Signed 32-bit integer. */
+typedef int32_t s32;
+/** Signed 64-bit integer. */
+typedef int64_t s64;
+/** Unsigned 8-bit integer. */
+typedef uint8_t u8;
+/** Unsigned 16-bit integer. */
+typedef uint16_t u16;
+/** Unsigned 32-bit integer. */
+typedef uint32_t u32;
+/** Unsigned 64-bit integer. */
+typedef uint64_t u64;
+
+#endif //LIBRTCM_COMMON_H

--- a/c/include/common.h
+++ b/c/include/common.h
@@ -1,6 +1,14 @@
-//
-// Created by Anthony Cole on 6/26/17.
-//
+/*
+ * Copyright (C) 2017 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
 
 #ifndef LIBRTCM_COMMON_H
 #define LIBRTCM_COMMON_H

--- a/c/include/constants.h
+++ b/c/include/constants.h
@@ -13,7 +13,6 @@
 #ifndef LIBRTCM_CONSTANTS_H
 #define LIBRTCM_CONSTANTS_H
 
-#define RTCM3_PREAMBLE 0xD3   /**< RTCM v3 Frame sync / preamble byte. */
 #define PRUNIT_GPS 299792.458 /**< RTCM v3 Unit of GPS Pseudorange (m) */
 #define PRUNIT_GLO 599584.916 /**< RTCM v3 Unit of GLO Pseudorange (m) */
 #define RTCM_MAX_SATS 32
@@ -22,10 +21,10 @@ static const double CLIGHT = 299792458.0; /* speed of light (m/s) */
 
 static const double GPS_L1_FREQ = 1.57542e9; /* GPS L1 frequency (Hz) */
 static const double GPS_L2_FREQ = 1.22760e9; /* GPS L2 Frequency */
-static const double GLO_L1_FREQ = 1.60172e9; /* GLO L1 frequency (Hz) */
-static const double GLO_L2_FREQ = 1.24578e9; /* GLO L2 Frequency */
-static const double GLO_L1_CH_OFFSET = 0.5625e9;    /* GLO L1 Channel offset */
-static const double GLO_L2_CH_OFFSET = 0.4375e9; /* GLO L2 Channel offset */
+static const double GLO_L1_FREQ = 1.602e9; /* GLO L1 frequency (Hz) */
+static const double GLO_L2_FREQ = 1.246e9; /* GLO L2 Frequency */
+static const double GLO_L1_CH_OFFSET = 0.5625e6;    /* GLO L1 Channel offset */
+static const double GLO_L2_CH_OFFSET = 0.4375e6; /* GLO L2 Channel offset */
 
 
 

--- a/c/include/constants.h
+++ b/c/include/constants.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2017 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef LIBRTCM_CONSTANTS_H
+#define LIBRTCM_CONSTANTS_H
+
+#define RTCM3_PREAMBLE 0xD3   /**< RTCM v3 Frame sync / preamble byte. */
+#define PRUNIT_GPS 299792.458 /**< RTCM v3 Unit of GPS Pseudorange (m) */
+#define PRUNIT_GLO 599584.916 /**< RTCM v3 Unit of GLO Pseudorange (m) */
+#define RTCM_MAX_SATS 32
+
+static const double CLIGHT = 299792458.0; /* speed of light (m/s) */
+
+static const double GPS_L1_FREQ = 1.57542e9; /* GPS L1 frequency (Hz) */
+static const double GPS_L2_FREQ = 1.22760e9; /* GPS L2 Frequency */
+static const double GLO_L1_FREQ = 1.60172e9; /* GLO L1 frequency (Hz) */
+static const double GLO_L2_FREQ = 1.24578e9; /* GLO L2 Frequency */
+static const double GLO_L1_CH_OFFSET = 0.5625e9;    /* GLO L1 Channel offset */
+static const double GLO_L2_CH_OFFSET = 0.4375e9; /* GLO L2 Channel offset */
+
+
+
+#endif //LIBRTCM_CONSTANTS_H

--- a/c/include/rtcm3_decode.h
+++ b/c/include/rtcm3_decode.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2017 Swift Navigation Inc.
+ * Contact: Jacob McNamee <jacob@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef SWIFTNAV_RTCM3_DECODE_H
+#define SWIFTNAV_RTCM3_DECODE_H
+
+#include <rtcm3_messages.h>
+#include <stdbool.h>
+
+u32 getbitu(const u8 *buff, u32 pos, u8 len);
+u64 getbitul(const u8 *buff, u32 pos, u8 len);
+s32 getbits(const u8 *buff, u32 pos, u8 len);
+s64 getbitsl(const u8 *buff, u32 pos, u8 len);
+void setbitu(u8 *buff, u32 pos, u32 len, u32 data);
+void setbitul(u8 *buff, u32 pos, u32 len, u64 data);
+void setbits(u8 *buff, u32 pos, u32 len, s32 data);
+void setbitsl(u8 *buff, u32 pos, u32 len, s64 data);
+
+#define RTCM3_PREAMBLE 0xD3   /**< RTCM v3 Frame sync / preamble byte. */
+#define PRUNIT_GPS 299792.458 /**< RTCM v3 Unit of GPS Pseudorange (m) */
+#define PRUNIT_GLO 599584.916 /**< RTCM v3 Unit of GLO Pseudorange (m) */
+
+u16 rtcm3_write_header(const rtcm_obs_header *header, u8 num_sats, u8 *buff);
+u16 rtcm3_read_header(const u8 *buff, rtcm_obs_header *header);
+static u8 to_lock_ind(u32 time);
+static u32 from_lock_ind(u8 lock);
+
+u16 rtcm3_encode_1001(const rtcm_obs_message *rtcm_msg_1001, u8 *buff);
+u16 rtcm3_encode_1002(const rtcm_obs_message *rtcm_msg_1002, u8 *buff);
+u16 rtcm3_encode_1003(const rtcm_obs_message *rtcm_msg_1003, u8 *buff);
+u16 rtcm3_encode_1004(const rtcm_obs_message *rtcm_msg_1004, u8 *buff);
+u16 rtcm3_encode_1005_base(const rtcm_msg_1005 *rtcm_msg_1005, u8 *buff,
+                           u16 *bit);
+u16 rtcm3_encode_1005(const rtcm_msg_1005 *rtcm_msg_1005, u8 *buff);
+u16 rtcm3_encode_1006(const rtcm_msg_1006 *rtcm_msg_1006, u8 *buff);
+u16 rtcm3_encode_1007_base(const rtcm_msg_1007 *rtcm_msg_1007, u8 *buff,
+                           u16 *bit);
+u16 rtcm3_encode_1007(const rtcm_msg_1007 *rtcm_msg_1007, u8 *buff);
+u16 rtcm3_encode_1008(const rtcm_msg_1008 *rtcm_msg_1008, u8 *buff);
+
+s8 rtcm3_decode_1001(const u8 *buff, rtcm_obs_message *rtcm_msg_1001);
+s8 rtcm3_decode_1002(const u8 *buff, rtcm_obs_message *rtcm_msg_1002);
+s8 rtcm3_decode_1003(const u8 *buff, rtcm_obs_message *rtcm_msg_1003);
+s8 rtcm3_decode_1004(const u8 *buff, rtcm_obs_message *rtcm_msg_1004);
+s8 rtcm3_decode_1005_base(const u8 *buff, rtcm_msg_1005 *rtcm_msg_1005,
+                          u16 *bit);
+s8 rtcm3_decode_1005(const u8 *buff, rtcm_msg_1005 *rtcm_msg_1005);
+s8 rtcm3_decode_1006(const u8 *buff, rtcm_msg_1006 *rtcm_msg_1006);
+s8 rtcm3_decode_1007_base(const u8 *buff, rtcm_msg_1007 *rtcm_msg_1007,
+                          u16 *bit);
+s8 rtcm3_decode_1007(const u8 *buff, rtcm_msg_1007 *rtcm_msg_1007);
+s8 rtcm3_decode_1008(const u8 *buff, rtcm_msg_1008 *rtcm_msg_1008);
+
+s8 rtcm3_decode_1010(const u8 *buff, rtcm_obs_message *rtcm_msg_1010);
+s8 rtcm3_decode_1012(const u8 *buff, rtcm_obs_message *rtcm_msg_1012);
+
+static s8 decode_basic_gps_l1_freq_data(const u8 *buff, u16 *bit,
+                                    rtcm_freq_data *freq_data, u32 *pr,
+                                    s32 *phr_pr_diff);
+static s8 decode_basic_glo_l1_freq_data(const u8 *buff, u16 *bit,
+                                    rtcm_freq_data *freq_data, u32 *pr,
+                                    s32 *phr_pr_diff);
+static s8 decode_basic_l2_freq_data(const u8 *buff, u16 *bit,
+                                    rtcm_freq_data *freq_data, s32 *pr,
+                                    s32 *phr_pr_diff);
+static void encode_basic_freq_data(const rtcm_freq_data *freq_data,
+                                 const double freq, const double *l1_pr, u8 *buff,
+                                 u16 *bit);
+static void init_data(rtcm_sat_data *sat_data);
+
+#endif /* SWIFTNAV_RTCM3_DECODE_H */

--- a/c/include/rtcm3_decode.h
+++ b/c/include/rtcm3_decode.h
@@ -24,10 +24,6 @@ void setbitul(u8 *buff, u32 pos, u32 len, u64 data);
 void setbits(u8 *buff, u32 pos, u32 len, s32 data);
 void setbitsl(u8 *buff, u32 pos, u32 len, s64 data);
 
-#define RTCM3_PREAMBLE 0xD3   /**< RTCM v3 Frame sync / preamble byte. */
-#define PRUNIT_GPS 299792.458 /**< RTCM v3 Unit of GPS Pseudorange (m) */
-#define PRUNIT_GLO 599584.916 /**< RTCM v3 Unit of GLO Pseudorange (m) */
-
 u16 rtcm3_write_header(const rtcm_obs_header *header, u8 num_sats, u8 *buff);
 u16 rtcm3_read_header(const u8 *buff, rtcm_obs_header *header);
 
@@ -35,12 +31,8 @@ u16 rtcm3_encode_1001(const rtcm_obs_message *rtcm_msg_1001, u8 *buff);
 u16 rtcm3_encode_1002(const rtcm_obs_message *rtcm_msg_1002, u8 *buff);
 u16 rtcm3_encode_1003(const rtcm_obs_message *rtcm_msg_1003, u8 *buff);
 u16 rtcm3_encode_1004(const rtcm_obs_message *rtcm_msg_1004, u8 *buff);
-u16 rtcm3_encode_1005_base(const rtcm_msg_1005 *rtcm_msg_1005, u8 *buff,
-                           u16 *bit);
 u16 rtcm3_encode_1005(const rtcm_msg_1005 *rtcm_msg_1005, u8 *buff);
 u16 rtcm3_encode_1006(const rtcm_msg_1006 *rtcm_msg_1006, u8 *buff);
-u16 rtcm3_encode_1007_base(const rtcm_msg_1007 *rtcm_msg_1007, u8 *buff,
-                           u16 *bit);
 u16 rtcm3_encode_1007(const rtcm_msg_1007 *rtcm_msg_1007, u8 *buff);
 u16 rtcm3_encode_1008(const rtcm_msg_1008 *rtcm_msg_1008, u8 *buff);
 
@@ -48,12 +40,8 @@ s8 rtcm3_decode_1001(const u8 *buff, rtcm_obs_message *rtcm_msg_1001);
 s8 rtcm3_decode_1002(const u8 *buff, rtcm_obs_message *rtcm_msg_1002);
 s8 rtcm3_decode_1003(const u8 *buff, rtcm_obs_message *rtcm_msg_1003);
 s8 rtcm3_decode_1004(const u8 *buff, rtcm_obs_message *rtcm_msg_1004);
-s8 rtcm3_decode_1005_base(const u8 *buff, rtcm_msg_1005 *rtcm_msg_1005,
-                          u16 *bit);
 s8 rtcm3_decode_1005(const u8 *buff, rtcm_msg_1005 *rtcm_msg_1005);
 s8 rtcm3_decode_1006(const u8 *buff, rtcm_msg_1006 *rtcm_msg_1006);
-s8 rtcm3_decode_1007_base(const u8 *buff, rtcm_msg_1007 *rtcm_msg_1007,
-                          u16 *bit);
 s8 rtcm3_decode_1007(const u8 *buff, rtcm_msg_1007 *rtcm_msg_1007);
 s8 rtcm3_decode_1008(const u8 *buff, rtcm_msg_1008 *rtcm_msg_1008);
 

--- a/c/include/rtcm3_decode.h
+++ b/c/include/rtcm3_decode.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (C) 2017 Swift Navigation Inc.
- * Contact: Jacob McNamee <jacob@swiftnav.com>
+ * Contact: Swift Navigation <dev@swiftnav.com>
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/include/rtcm3_decode.h
+++ b/c/include/rtcm3_decode.h
@@ -19,33 +19,18 @@ u32 getbitu(const u8 *buff, u32 pos, u8 len);
 u64 getbitul(const u8 *buff, u32 pos, u8 len);
 s32 getbits(const u8 *buff, u32 pos, u8 len);
 s64 getbitsl(const u8 *buff, u32 pos, u8 len);
-void setbitu(u8 *buff, u32 pos, u32 len, u32 data);
-void setbitul(u8 *buff, u32 pos, u32 len, u64 data);
-void setbits(u8 *buff, u32 pos, u32 len, s32 data);
-void setbitsl(u8 *buff, u32 pos, u32 len, s64 data);
 
-u16 rtcm3_write_header(const rtcm_obs_header *header, u8 num_sats, u8 *buff);
 u16 rtcm3_read_header(const u8 *buff, rtcm_obs_header *header);
 
-u16 rtcm3_encode_1001(const rtcm_obs_message *rtcm_msg_1001, u8 *buff);
-u16 rtcm3_encode_1002(const rtcm_obs_message *rtcm_msg_1002, u8 *buff);
-u16 rtcm3_encode_1003(const rtcm_obs_message *rtcm_msg_1003, u8 *buff);
-u16 rtcm3_encode_1004(const rtcm_obs_message *rtcm_msg_1004, u8 *buff);
-u16 rtcm3_encode_1005(const rtcm_msg_1005 *rtcm_msg_1005, u8 *buff);
-u16 rtcm3_encode_1006(const rtcm_msg_1006 *rtcm_msg_1006, u8 *buff);
-u16 rtcm3_encode_1007(const rtcm_msg_1007 *rtcm_msg_1007, u8 *buff);
-u16 rtcm3_encode_1008(const rtcm_msg_1008 *rtcm_msg_1008, u8 *buff);
-
-s8 rtcm3_decode_1001(const u8 *buff, rtcm_obs_message *rtcm_msg_1001);
-s8 rtcm3_decode_1002(const u8 *buff, rtcm_obs_message *rtcm_msg_1002);
-s8 rtcm3_decode_1003(const u8 *buff, rtcm_obs_message *rtcm_msg_1003);
-s8 rtcm3_decode_1004(const u8 *buff, rtcm_obs_message *rtcm_msg_1004);
-s8 rtcm3_decode_1005(const u8 *buff, rtcm_msg_1005 *rtcm_msg_1005);
-s8 rtcm3_decode_1006(const u8 *buff, rtcm_msg_1006 *rtcm_msg_1006);
-s8 rtcm3_decode_1007(const u8 *buff, rtcm_msg_1007 *rtcm_msg_1007);
-s8 rtcm3_decode_1008(const u8 *buff, rtcm_msg_1008 *rtcm_msg_1008);
-
-s8 rtcm3_decode_1010(const u8 *buff, rtcm_obs_message *rtcm_msg_1010);
-s8 rtcm3_decode_1012(const u8 *buff, rtcm_obs_message *rtcm_msg_1012);
+s8 rtcm3_decode_1001(const u8 *buff, rtcm_obs_message *msg_1001);
+s8 rtcm3_decode_1002(const u8 *buff, rtcm_obs_message *msg_1002);
+s8 rtcm3_decode_1003(const u8 *buff, rtcm_obs_message *msg_1003);
+s8 rtcm3_decode_1004(const u8 *buff, rtcm_obs_message *msg_1004);
+s8 rtcm3_decode_1005(const u8 *buff, rtcm_msg_1005 *msg_1005);
+s8 rtcm3_decode_1006(const u8 *buff, rtcm_msg_1006 *msg_1006);
+s8 rtcm3_decode_1007(const u8 *buff, rtcm_msg_1007 *msg_1007);
+s8 rtcm3_decode_1008(const u8 *buff, rtcm_msg_1008 *msg_1008);
+s8 rtcm3_decode_1010(const u8 *buff, rtcm_obs_message *msg_1010);
+s8 rtcm3_decode_1012(const u8 *buff, rtcm_obs_message *msg_1012);
 
 #endif /* SWIFTNAV_RTCM3_DECODE_H */

--- a/c/include/rtcm3_decode.h
+++ b/c/include/rtcm3_decode.h
@@ -14,7 +14,6 @@
 #define SWIFTNAV_RTCM3_DECODE_H
 
 #include <rtcm3_messages.h>
-#include <stdbool.h>
 
 u32 getbitu(const u8 *buff, u32 pos, u8 len);
 u64 getbitul(const u8 *buff, u32 pos, u8 len);
@@ -31,8 +30,6 @@ void setbitsl(u8 *buff, u32 pos, u32 len, s64 data);
 
 u16 rtcm3_write_header(const rtcm_obs_header *header, u8 num_sats, u8 *buff);
 u16 rtcm3_read_header(const u8 *buff, rtcm_obs_header *header);
-static u8 to_lock_ind(u32 time);
-static u32 from_lock_ind(u8 lock);
 
 u16 rtcm3_encode_1001(const rtcm_obs_message *rtcm_msg_1001, u8 *buff);
 u16 rtcm3_encode_1002(const rtcm_obs_message *rtcm_msg_1002, u8 *buff);
@@ -62,19 +59,5 @@ s8 rtcm3_decode_1008(const u8 *buff, rtcm_msg_1008 *rtcm_msg_1008);
 
 s8 rtcm3_decode_1010(const u8 *buff, rtcm_obs_message *rtcm_msg_1010);
 s8 rtcm3_decode_1012(const u8 *buff, rtcm_obs_message *rtcm_msg_1012);
-
-static s8 decode_basic_gps_l1_freq_data(const u8 *buff, u16 *bit,
-                                    rtcm_freq_data *freq_data, u32 *pr,
-                                    s32 *phr_pr_diff);
-static s8 decode_basic_glo_l1_freq_data(const u8 *buff, u16 *bit,
-                                    rtcm_freq_data *freq_data, u32 *pr,
-                                    s32 *phr_pr_diff);
-static s8 decode_basic_l2_freq_data(const u8 *buff, u16 *bit,
-                                    rtcm_freq_data *freq_data, s32 *pr,
-                                    s32 *phr_pr_diff);
-static void encode_basic_freq_data(const rtcm_freq_data *freq_data,
-                                 const double freq, const double *l1_pr, u8 *buff,
-                                 u16 *bit);
-static void init_data(rtcm_sat_data *sat_data);
 
 #endif /* SWIFTNAV_RTCM3_DECODE_H */

--- a/c/include/rtcm3_messages.h
+++ b/c/include/rtcm3_messages.h
@@ -40,7 +40,6 @@ typedef union {
 
 typedef struct {
   u8 code;
-  u8 fcn;
   double pseudorange;
   double carrier_phase;
   u32 lock;
@@ -51,6 +50,7 @@ typedef struct {
 
 typedef struct {
   u8 svId;
+  u8 fcn;
   rtcm_freq_data obs[NUM_FREQS];
 } rtcm_sat_data;
 

--- a/c/include/rtcm3_messages.h
+++ b/c/include/rtcm3_messages.h
@@ -1,0 +1,97 @@
+//
+// Created by pgrgich on 3/14/17.
+//
+
+#ifndef PIKSI_BUILDROOT_RTCM3_MESSAGES_H_H
+#define PIKSI_BUILDROOT_RTCM3_MESSAGES_H_H
+
+#include <common.h>
+
+#define RTCM_MAX_SATS 32
+
+typedef enum { L1_FREQ, L2_FREQ, NUM_FREQS } freq_enum;
+
+static const double CLIGHT = 299792458.0; /* speed of light (m/s) */
+
+static const double GPS_L1_FREQ = 1.57542e9; /* GPS L1 frequency (Hz) */
+static const double GPS_L2_FREQ = 1.22760e9; /* GPS L2 Frequency */
+static const double GLO_L1_FREQ = 1.60172e9; /* GLO L1 frequency (Hz) */
+static const double GLO_L2_FREQ = 1.24578e9; /* GLO L2 Frequency */
+static const double GLO_L1_CH_OFFSET = 0.5625e9;    /* GLO L1 Channel offset */
+static const double GLO_L2_CH_OFFSET = 0.4375e9; /* GLO L2 Channel offset */
+
+typedef struct {
+  u16 msg_num;
+  u16 stn_id;
+  u32 tow;
+  u8 sync;
+  u8 n_sat;
+  u8 div_free;
+  u8 smooth;
+} rtcm_obs_header;
+
+typedef union {
+  struct {
+    u8 valid_pr : 1;
+    u8 valid_cp : 1;
+    u8 valid_cnr : 1;
+    u8 valid_lock : 1;
+  };
+  u8 data;
+} flag_bf;
+
+typedef struct {
+  u8 code;
+  u8 fcn;
+  double pseudorange;
+  double carrier_phase;
+  u32 lock;
+  double cnr;
+  flag_bf flags;
+
+} rtcm_freq_data;
+
+typedef struct {
+  u8 svId;
+  rtcm_freq_data obs[NUM_FREQS];
+} rtcm_sat_data;
+
+typedef struct {
+  rtcm_obs_header header;
+  rtcm_sat_data sats[RTCM_MAX_SATS];
+} rtcm_obs_message;
+
+typedef struct {
+  u16 stn_id;         // Reference Station ID DF003 uint12 12
+  u8 ITRF;            // Reserved for ITRF Realization Year DF021 uint6 6
+  u8 GPS_ind;         // GPS Indicator DF022 bit(1) 1
+  u8 GLO_ind;         // GLONASS Indicator DF023 bit(1) 1
+  u8 GAL_ind;         // Reserved for Galileo Indicator DF024 bit(1) 1
+  u8 ref_stn_ind;     // Reference-Station Indicator DF141 bit(1) 1
+  double arp_x;       // Antenna Reference Point ECEF-X DF025 int38 38
+  u8 osc_ind;         // Single Receiver Oscillator Indicator DF142 bit(1) 1
+  u8 reserved;        // Reserved DF001 bit(1) 1
+  double arp_y;       // Antenna Reference Point ECEF-Y DF026 int38 38
+  u8 quart_cycle_ind; // Quarter Cycle Indicator DF364 bit(2) 2
+  double arp_z;       // Antenna Reference Point ECEF-Z DF027 int38 38
+} rtcm_msg_1005;
+
+typedef struct {
+  rtcm_msg_1005 msg_1005;
+  double ant_height; // Antenna Height DF028 uint16 16
+} rtcm_msg_1006;
+
+typedef struct {
+  u16 stn_id;    // Reference Station ID DF003 uint12 12
+  u8 desc_count; // Descriptor Counter N DF029 uint8 8 N <= 31
+  char desc[32]; // Antenna Descriptor DF030 char8(N) 8*N
+  u8 ant_id;     // Antenna Setup ID DF031 uint8 8
+} rtcm_msg_1007;
+
+typedef struct {
+  rtcm_msg_1007 msg_1007;
+  u8 serial_count;     // Serial Number Counter M DF032 uint8 8 M <= 31
+  char serial_num[32]; // Antenna Serial Number DF033 char8(M) 8*M
+} rtcm_msg_1008;
+
+#endif // PIKSI_BUILDROOT_RTCM3_MESSAGES_H_H

--- a/c/include/rtcm3_messages.h
+++ b/c/include/rtcm3_messages.h
@@ -14,28 +14,18 @@
 #define PIKSI_BUILDROOT_RTCM3_MESSAGES_H_H
 
 #include <common.h>
-
-#define RTCM_MAX_SATS 32
+#include <constants.h>
 
 typedef enum { L1_FREQ, L2_FREQ, NUM_FREQS } freq_enum;
 
-static const double CLIGHT = 299792458.0; /* speed of light (m/s) */
-
-static const double GPS_L1_FREQ = 1.57542e9; /* GPS L1 frequency (Hz) */
-static const double GPS_L2_FREQ = 1.22760e9; /* GPS L2 Frequency */
-static const double GLO_L1_FREQ = 1.60172e9; /* GLO L1 frequency (Hz) */
-static const double GLO_L2_FREQ = 1.24578e9; /* GLO L2 Frequency */
-static const double GLO_L1_CH_OFFSET = 0.5625e9;    /* GLO L1 Channel offset */
-static const double GLO_L2_CH_OFFSET = 0.4375e9; /* GLO L2 Channel offset */
-
 typedef struct {
-  u16 msg_num;
-  u16 stn_id;
-  u32 tow;
-  u8 sync;
-  u8 n_sat;
-  u8 div_free;
-  u8 smooth;
+  u16 msg_num;      /* Msg Num DF002 uint16 12*/
+  u16 stn_id;       /* Station Id DF003 uint16 12*/
+  u32 tow;          /* GPS time of week DF004 uint32 30 */
+  u8 sync;          /* Syncronous flag DF005 bit(1) 1 */
+  u8 n_sat;         /* Number of satellites DF006 uint8 5 */
+  u8 div_free;      /* Divergance free flag DF007 bit(1) 1 */
+  u8 smooth;        /* GPS Smoothing Interval DF008 bit(3) 3 */
 } rtcm_obs_header;
 
 typedef union {
@@ -70,36 +60,36 @@ typedef struct {
 } rtcm_obs_message;
 
 typedef struct {
-  u16 stn_id;         // Reference Station ID DF003 uint12 12
-  u8 ITRF;            // Reserved for ITRF Realization Year DF021 uint6 6
-  u8 GPS_ind;         // GPS Indicator DF022 bit(1) 1
-  u8 GLO_ind;         // GLONASS Indicator DF023 bit(1) 1
-  u8 GAL_ind;         // Reserved for Galileo Indicator DF024 bit(1) 1
-  u8 ref_stn_ind;     // Reference-Station Indicator DF141 bit(1) 1
-  double arp_x;       // Antenna Reference Point ECEF-X DF025 int38 38
-  u8 osc_ind;         // Single Receiver Oscillator Indicator DF142 bit(1) 1
-  u8 reserved;        // Reserved DF001 bit(1) 1
-  double arp_y;       // Antenna Reference Point ECEF-Y DF026 int38 38
-  u8 quart_cycle_ind; // Quarter Cycle Indicator DF364 bit(2) 2
-  double arp_z;       // Antenna Reference Point ECEF-Z DF027 int38 38
+  u16 stn_id;
+  u8 ITRF;            /* Reserved for ITRF Realization Year DF021 uint6 6 */
+  u8 GPS_ind;         /* GPS Indicator DF022 bit(1) 1 */
+  u8 GLO_ind;         /* GLONASS Indicator DF023 bit(1) 1 */
+  u8 GAL_ind;         /* Reserved for Galileo Indicator DF024 bit(1) 1 */
+  u8 ref_stn_ind;     /* Reference-Station Indicator DF141 bit(1) 1 */
+  double arp_x;       /* Antenna Reference Point ECEF-X DF025 int38 38 */
+  u8 osc_ind;         /* Single Receiver Oscillator Indicator DF142 bit(1) 1 */
+  u8 reserved;        /* Reserved DF001 bit(1) 1 */
+  double arp_y;       /* Antenna Reference Point ECEF-Y DF026 int38 38 */
+  u8 quart_cycle_ind; /* Quarter Cycle Indicator DF364 bit(2) 2 */
+  double arp_z;       /* Antenna Reference Point ECEF-Z DF027 int38 38 */
 } rtcm_msg_1005;
 
 typedef struct {
   rtcm_msg_1005 msg_1005;
-  double ant_height; // Antenna Height DF028 uint16 16
+  double ant_height; /* Antenna Height DF028 uint16 16 */
 } rtcm_msg_1006;
 
 typedef struct {
-  u16 stn_id;    // Reference Station ID DF003 uint12 12
-  u8 desc_count; // Descriptor Counter N DF029 uint8 8 N <= 31
-  char desc[32]; // Antenna Descriptor DF030 char8(N) 8*N
-  u8 ant_id;     // Antenna Setup ID DF031 uint8 8
+  u16 stn_id;    /* Reference Station ID DF003 uint12 12 */
+  u8 desc_count; /* Descriptor Counter N DF029 uint8 8 N <= 31 */
+  char desc[32]; /* Antenna Descriptor DF030 char8(N) 8*N */
+  u8 ant_id;     /* Antenna Setup ID DF031 uint8 8 */
 } rtcm_msg_1007;
 
 typedef struct {
   rtcm_msg_1007 msg_1007;
-  u8 serial_count;     // Serial Number Counter M DF032 uint8 8 M <= 31
-  char serial_num[32]; // Antenna Serial Number DF033 char8(M) 8*M
+  u8 serial_count;     /* Serial Number Counter M DF032 uint8 8 M <= 31 */
+  char serial_num[32]; /* Antenna Serial Number DF033 char8(M) 8*M */
 } rtcm_msg_1008;
 
-#endif // PIKSI_BUILDROOT_RTCM3_MESSAGES_H_H
+#endif /* PIKSI_BUILDROOT_RTCM3_MESSAGES_H_H */

--- a/c/include/rtcm3_messages.h
+++ b/c/include/rtcm3_messages.h
@@ -1,6 +1,14 @@
-//
-// Created by pgrgich on 3/14/17.
-//
+/*
+ * Copyright (C) 2017 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
 
 #ifndef PIKSI_BUILDROOT_RTCM3_MESSAGES_H_H
 #define PIKSI_BUILDROOT_RTCM3_MESSAGES_H_H

--- a/c/src/CMakeLists.txt
+++ b/c/src/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 2.8.7)
+project(librtcm)
+
+add_library (librtcm rtcm3_decode.c)
+
+target_include_directories (librtcm PUBLIC ../include)

--- a/c/src/CMakeLists.txt
+++ b/c/src/CMakeLists.txt
@@ -2,5 +2,5 @@ cmake_minimum_required(VERSION 2.8.7)
 project(librtcm)
 
 add_library (librtcm rtcm3_decode.c)
-
+target_link_libraries(librtcm m)
 target_include_directories (librtcm PUBLIC ../include)

--- a/c/src/rtcm3_decode.c
+++ b/c/src/rtcm3_decode.c
@@ -54,6 +54,158 @@ u64 getbitul(const u8 *buff, u32 pos, u8 len) {
   return bits;
 }
 
+/** Convert a lock time in seconds into a RTCMv3 Lock Time Indicator value.
+ * See RTCM 10403.1, Table 3.4-2.
+ *
+ * \param time Lock time in seconds.
+ * \return Lock Time Indicator value.
+ */
+static u8 to_lock_ind(u32 time) {
+  if (time < 24)
+    return time;
+  if (time < 72)
+    return (time + 24) / 2;
+  if (time < 168)
+    return (time + 120) / 4;
+  if (time < 360)
+    return (time + 408) / 8;
+  if (time < 744)
+    return (time + 1176) / 16;
+  if (time < 937)
+    return (time + 3096) / 32;
+  return 127;
+}
+
+static u32 from_lock_ind(u8 lock) {
+  if (lock < 24)
+    return lock;
+  if (lock < 48)
+    return 2 * lock - 24;
+  if (lock < 72)
+    return 4 * lock - 120;
+  if (lock < 96)
+    return 8 * lock - 408;
+  if (lock < 120)
+    return 16 * lock - 1176;
+  if (lock < 127)
+    return 32 * lock - 3096;
+  return 937;
+}
+
+void decode_basic_gps_l1_freq_data(const u8 *buff, u16 *bit,
+                                   rtcm_freq_data *freq_data, u32 *pr,
+                                   s32 *phr_pr_diff) {
+  freq_data->code = getbitu(buff, *bit, 1);
+  *bit += 1;
+  *pr = getbitu(buff, *bit, 24);
+  *bit += 24;
+  *phr_pr_diff = getbits(buff, *bit, 20);
+  *bit += 20;
+
+  freq_data->lock = from_lock_ind(getbitu(buff, *bit, 7));
+  *bit += 7;
+  freq_data->flags.valid_lock = 1;
+
+  return;
+}
+
+void decode_basic_glo_l1_freq_data(const u8 *buff, u16 *bit,
+                                   rtcm_freq_data *freq_data, u32 *pr,
+                                   s32 *phr_pr_diff) {
+  freq_data->code = getbitu(buff, *bit, 1);
+  *bit += 1;
+  freq_data->fcn = getbitu(buff, *bit, 5);
+  *bit += 5;
+  *pr = getbitu(buff, *bit, 25);
+  *bit += 25;
+  *phr_pr_diff = getbits(buff, *bit, 20);
+  *bit += 20;
+
+  freq_data->lock = from_lock_ind(getbitu(buff, *bit, 7));
+  *bit += 7;
+  freq_data->flags.valid_lock = 1;
+
+  return;
+}
+
+void decode_basic_l2_freq_data(const u8 *buff, u16 *bit,
+                               rtcm_freq_data *freq_data, s32 *pr,
+                               s32 *phr_pr_diff) {
+  freq_data->code = getbitu(buff, *bit, 2);
+  *bit += 2;
+  *pr = getbits(buff, *bit, 14);
+  *bit += 14;
+  *phr_pr_diff = getbits(buff, *bit, 20);
+  *bit += 20;
+
+  freq_data->lock = from_lock_ind(getbitu(buff, *bit, 7));
+  *bit += 7;
+  freq_data->flags.valid_lock = 1;
+
+  return;
+}
+
+void init_data(rtcm_sat_data *sat_data) {
+  for (u8 freq = 0; freq < NUM_FREQS; ++freq) {
+    sat_data->obs[freq].flags.data = 0;
+  }
+}
+
+void encode_basic_freq_data(const rtcm_freq_data *freq_data, const double freq,
+                            const double *l1_pr, u8 *buff, u16 *bit) {
+
+  /* Calculate GPS Integer L1 Pseudorange Modulus Ambiguity (DF014). */
+  u8 amb = (u8)(*l1_pr / PRUNIT_GPS);
+
+  /* Construct L1 pseudorange value as it would be transmitted (DF011). */
+  u32 calc_l1_pr = (u32)roundl((double)(*l1_pr - amb * PRUNIT_GPS) / 0.02);
+
+  /* Calculate GPS Pseudorange (DF011/DF016). */
+  u32 pr = (u32)roundl((freq_data->pseudorange - amb * PRUNIT_GPS) / 0.02);
+
+  double l1_prc = calc_l1_pr * 0.02 + amb * PRUNIT_GPS;
+
+  /* phaserange - L1 pseudorange */
+  double cp_pr = freq_data->carrier_phase - l1_prc / (CLIGHT / freq);
+
+  // pgrgich: TO DO!!
+  //  /* If the phaserange and pseudorange have diverged close to the limits of
+  //  the
+  //   * data field (20 bits) then we modify the carrier phase by an integer
+  //   amount
+  //   * to bring it back into range an reset the phase lock time to zero to
+  //   reset
+  //   * the integer ambiguity.
+  //   * The spec suggests adjusting by 1500 cycles but I calculate the range to
+  //   be
+  //   * +/- 1379 cycles. Limit to just 1000 as that should still be plenty. */
+  //  if (fabs(cp_pr) > 1000) {
+  //    nm->lock_time = 0;
+  //    nm->raw_carrier_phase -= (s32)cp_pr;
+  //    cp_pr -= (s32)cp_pr;
+  //  }
+
+  /* Calculate GPS PhaseRange – L1 Pseudorange (DF012/DF018). */
+  s32 ppr = roundl(cp_pr * (CLIGHT / freq) / 0.0005);
+
+  if (freq == GPS_L1_FREQ) {
+    setbitu(buff, *bit, 1, 0);
+    *bit += 1;
+    setbitu(buff, *bit, 24, pr);
+    *bit += 24;
+  } else {
+    setbitu(buff, *bit, 2, 0);
+    *bit += 2;
+    setbits(buff, *bit, 14, (s32)pr - (s32)calc_l1_pr);
+    *bit += 14;
+  }
+  setbits(buff, *bit, 20, ppr);
+  *bit += 20;
+  setbitu(buff, *bit, 7,
+          freq_data->flags.valid_lock ? to_lock_ind(freq_data->lock) : 0);
+  *bit += 7;
+}
+
 /** Get bit field from buffer as a signed integer.
  * Unpacks `len` bits at bit position `pos` from the start of the buffer.
  * Maximum bit field length is 32 bits, i.e. `len <= 32`.
@@ -295,68 +447,23 @@ u16 rtcm3_read_glo_header(const u8 *buff, rtcm_obs_header *header) {
   return bit;
 }
 
-/** Convert a lock time in seconds into a RTCMv3 Lock Time Indicator value.
- * See RTCM 10403.1, Table 3.4-2.
- *
- * \param time Lock time in seconds.
- * \return Lock Time Indicator value.
- */
-static u8 to_lock_ind(u32 time) {
-  if (time < 24)
-    return time;
-  if (time < 72)
-    return (time + 24) / 2;
-  if (time < 168)
-    return (time + 120) / 4;
-  if (time < 360)
-    return (time + 408) / 8;
-  if (time < 744)
-    return (time + 1176) / 16;
-  if (time < 937)
-    return (time + 3096) / 32;
-  return 127;
-}
-
-/** Convert a RTCMv3 Lock Time Indicator value into a minimum lock time in
- * seconds.
- * See RTCM 10403.1, Table 3.4-2.
- *
- * \param lock Lock Time Indicator value.
- * \return Minimum lock time in seconds.
- */
-static u32 from_lock_ind(u8 lock) {
-  if (lock < 24)
-    return lock;
-  if (lock < 48)
-    return 2 * lock - 24;
-  if (lock < 72)
-    return 4 * lock - 120;
-  if (lock < 96)
-    return 8 * lock - 408;
-  if (lock < 120)
-    return 16 * lock - 1176;
-  if (lock < 127)
-    return 32 * lock - 3096;
-  return 937;
-}
-
-u16 rtcm3_encode_1001(const rtcm_obs_message *rtcm_msg_1001, u8 *buff) {
+u16 rtcm3_encode_1001(const rtcm_obs_message *msg_1001, u8 *buff) {
   u16 bit = 64; /* Start at end of header. */
 
   u8 num_sats = 0;
-  for (u8 i = 0; i < rtcm_msg_1001->header.n_sat; i++) {
-    if (rtcm_msg_1001->sats[i].obs[L1_FREQ].flags.valid_pr &&
-        rtcm_msg_1001->sats[i].obs[L1_FREQ].flags.valid_cp) {
-      setbitu(buff, bit, 6, rtcm_msg_1001->sats[i].svId);
+  for (u8 i = 0; i < msg_1001->header.n_sat; i++) {
+    if (msg_1001->sats[i].obs[L1_FREQ].flags.valid_pr &&
+      msg_1001->sats[i].obs[L1_FREQ].flags.valid_cp) {
+      setbitu(buff, bit, 6, msg_1001->sats[i].svId);
       bit += 6;
-      encode_basic_freq_data(&rtcm_msg_1001->sats[i].obs[L1_FREQ], GPS_L1_FREQ,
-                             &rtcm_msg_1001->sats[i].obs[L1_FREQ].pseudorange,
+      encode_basic_freq_data(&msg_1001->sats[i].obs[L1_FREQ], GPS_L1_FREQ,
+                             &msg_1001->sats[i].obs[L1_FREQ].pseudorange,
                              buff, &bit);
       ++num_sats;
     }
   }
 
-  rtcm3_write_header(&rtcm_msg_1001->header, num_sats, buff);
+  rtcm3_write_header(&msg_1001->header, num_sats, buff);
 
   /* Round number of bits up to nearest whole byte. */
   return (bit + 7) / 8;
@@ -374,189 +481,189 @@ u16 rtcm3_encode_1001(const rtcm_obs_message *rtcm_msg_1001, u8 *buff) {
  * \param sync Synchronous GNSS Flag (DF005).
  * \return The message length in bytes.
  */
-u16 rtcm3_encode_1002(const rtcm_obs_message *rtcm_msg_1002, u8 *buff) {
+u16 rtcm3_encode_1002(const rtcm_obs_message *msg_1002, u8 *buff) {
   u16 bit = 64; /* Start at end of header. */
 
   u8 num_sats = 0;
-  for (u8 i = 0; i < rtcm_msg_1002->header.n_sat; i++) {
-    if (rtcm_msg_1002->sats[i].obs[L1_FREQ].flags.valid_pr &&
-        rtcm_msg_1002->sats[i].obs[L1_FREQ].flags.valid_cp) {
-      setbitu(buff, bit, 6, rtcm_msg_1002->sats[i].svId);
+  for (u8 i = 0; i < msg_1002->header.n_sat; i++) {
+    if (msg_1002->sats[i].obs[L1_FREQ].flags.valid_pr &&
+        msg_1002->sats[i].obs[L1_FREQ].flags.valid_cp) {
+      setbitu(buff, bit, 6, msg_1002->sats[i].svId);
       bit += 6;
-      encode_basic_freq_data(&rtcm_msg_1002->sats[i].obs[L1_FREQ], GPS_L1_FREQ,
-                             &rtcm_msg_1002->sats[i].obs[L1_FREQ].pseudorange,
+      encode_basic_freq_data(&msg_1002->sats[i].obs[L1_FREQ], GPS_L1_FREQ,
+                             &msg_1002->sats[i].obs[L1_FREQ].pseudorange,
                              buff, &bit);
 
       /* Calculate GPS Integer L1 Pseudorange Modulus Ambiguity (DF014). */
       u8 amb =
-          (u8)(rtcm_msg_1002->sats[i].obs[L1_FREQ].pseudorange / PRUNIT_GPS);
+          (u8)(msg_1002->sats[i].obs[L1_FREQ].pseudorange / PRUNIT_GPS);
 
       setbitu(buff, bit, 8, amb);
       bit += 8;
       setbitu(buff, bit, 8,
-              (u8)roundl(rtcm_msg_1002->sats[i].obs[L1_FREQ].cnr * 4.0));
+              (u8)roundl(msg_1002->sats[i].obs[L1_FREQ].cnr * 4.0));
       bit += 8;
       ++num_sats;
     }
   }
 
-  rtcm3_write_header(&rtcm_msg_1002->header, num_sats, buff);
+  rtcm3_write_header(&msg_1002->header, num_sats, buff);
 
   /* Round number of bits up to nearest whole byte. */
   return (bit + 7) / 8;
 }
 
-u16 rtcm3_encode_1003(const rtcm_obs_message *rtcm_msg_1003, u8 *buff) {
+u16 rtcm3_encode_1003(const rtcm_obs_message *msg_1003, u8 *buff) {
   u16 bit = 64; /* Start at end of header. */
 
   u8 num_sats = 0;
-  for (u8 i = 0; i < rtcm_msg_1003->header.n_sat; i++) {
-    flag_bf l1_flags = rtcm_msg_1003->sats[i].obs[L1_FREQ].flags;
-    flag_bf l2_flags = rtcm_msg_1003->sats[i].obs[L2_FREQ].flags;
+  for (u8 i = 0; i < msg_1003->header.n_sat; i++) {
+    flag_bf l1_flags = msg_1003->sats[i].obs[L1_FREQ].flags;
+    flag_bf l2_flags = msg_1003->sats[i].obs[L2_FREQ].flags;
     if (l1_flags.valid_pr && l1_flags.valid_cp && l2_flags.valid_pr &&
         l2_flags.valid_cp) {
-      setbitu(buff, bit, 6, rtcm_msg_1003->sats[i].svId);
+      setbitu(buff, bit, 6, msg_1003->sats[i].svId);
       bit += 6;
-      encode_basic_freq_data(&rtcm_msg_1003->sats[i].obs[L1_FREQ], GPS_L1_FREQ,
-                             &rtcm_msg_1003->sats[i].obs[L1_FREQ].pseudorange,
+      encode_basic_freq_data(&msg_1003->sats[i].obs[L1_FREQ], GPS_L1_FREQ,
+                             &msg_1003->sats[i].obs[L1_FREQ].pseudorange,
                              buff, &bit);
-      encode_basic_freq_data(&rtcm_msg_1003->sats[i].obs[L2_FREQ], GPS_L2_FREQ,
-                             &rtcm_msg_1003->sats[i].obs[L1_FREQ].pseudorange,
+      encode_basic_freq_data(&msg_1003->sats[i].obs[L2_FREQ], GPS_L2_FREQ,
+                             &msg_1003->sats[i].obs[L1_FREQ].pseudorange,
                              buff, &bit);
       ++num_sats;
     }
   }
 
-  rtcm3_write_header(&rtcm_msg_1003->header, num_sats, buff);
+  rtcm3_write_header(&msg_1003->header, num_sats, buff);
 
   /* Round number of bits up to nearest whole byte. */
   return (bit + 7) / 8;
 }
 
-u16 rtcm3_encode_1004(const rtcm_obs_message *rtcm_msg_1004, u8 *buff) {
+u16 rtcm3_encode_1004(const rtcm_obs_message *msg_1004, u8 *buff) {
   u16 bit = 64; /* Start at end of header. */
 
   u8 num_sats = 0;
-  for (u8 i = 0; i < rtcm_msg_1004->header.n_sat; i++) {
-    flag_bf l1_flags = rtcm_msg_1004->sats[i].obs[L1_FREQ].flags;
-    flag_bf l2_flags = rtcm_msg_1004->sats[i].obs[L2_FREQ].flags;
+  for (u8 i = 0; i < msg_1004->header.n_sat; i++) {
+    flag_bf l1_flags = msg_1004->sats[i].obs[L1_FREQ].flags;
+    flag_bf l2_flags = msg_1004->sats[i].obs[L2_FREQ].flags;
     if (l1_flags.valid_pr && l1_flags.valid_cp && l2_flags.valid_pr &&
         l2_flags.valid_cp) {
-      setbitu(buff, bit, 6, rtcm_msg_1004->sats[i].svId);
+      setbitu(buff, bit, 6, msg_1004->sats[i].svId);
       bit += 6;
-      encode_basic_freq_data(&rtcm_msg_1004->sats[i].obs[L1_FREQ], GPS_L1_FREQ,
-                             &rtcm_msg_1004->sats[i].obs[L1_FREQ].pseudorange,
+      encode_basic_freq_data(&msg_1004->sats[i].obs[L1_FREQ], GPS_L1_FREQ,
+                             &msg_1004->sats[i].obs[L1_FREQ].pseudorange,
                              buff, &bit);
 
       /* Calculate GPS Integer L1 Pseudorange Modulus Ambiguity (DF014). */
       u8 amb =
-          (u8)(rtcm_msg_1004->sats[i].obs[L1_FREQ].pseudorange / PRUNIT_GPS);
+          (u8)(msg_1004->sats[i].obs[L1_FREQ].pseudorange / PRUNIT_GPS);
 
       setbitu(buff, bit, 8, amb);
       bit += 8;
       setbitu(buff, bit, 8,
-              (u8)roundl(rtcm_msg_1004->sats[i].obs[L1_FREQ].cnr * 4.0));
+              (u8)roundl(msg_1004->sats[i].obs[L1_FREQ].cnr * 4.0));
       bit += 8;
 
-      encode_basic_freq_data(&rtcm_msg_1004->sats[i].obs[L2_FREQ], GPS_L2_FREQ,
-                             &rtcm_msg_1004->sats[i].obs[L1_FREQ].pseudorange,
+      encode_basic_freq_data(&msg_1004->sats[i].obs[L2_FREQ], GPS_L2_FREQ,
+                             &msg_1004->sats[i].obs[L1_FREQ].pseudorange,
                              buff, &bit);
       setbitu(buff, bit, 8,
-              (u8)roundl(rtcm_msg_1004->sats[i].obs[L2_FREQ].cnr * 4.0));
+              (u8)roundl(msg_1004->sats[i].obs[L2_FREQ].cnr * 4.0));
       bit += 8;
       ++num_sats;
     }
   }
 
-  rtcm3_write_header(&rtcm_msg_1004->header, num_sats, buff);
+  rtcm3_write_header(&msg_1004->header, num_sats, buff);
 
   /* Round number of bits up to nearest whole byte. */
   return (bit + 7) / 8;
 }
 
-u16 rtcm3_encode_1005_base(const rtcm_msg_1005 *rtcm_msg_1005, u8 *buff,
+u16 rtcm3_encode_1005_base(const rtcm_msg_1005 *msg_1005, u8 *buff,
                            u16 *bit) {
-  setbitu(buff, *bit, 12, rtcm_msg_1005->stn_id);
+  setbitu(buff, *bit, 12, msg_1005->stn_id);
   *bit += 12;
-  setbitu(buff, *bit, 6, rtcm_msg_1005->ITRF);
+  setbitu(buff, *bit, 6, msg_1005->ITRF);
   *bit += 6;
-  setbitu(buff, *bit, 1, rtcm_msg_1005->GPS_ind);
+  setbitu(buff, *bit, 1, msg_1005->GPS_ind);
   *bit += 1;
-  setbitu(buff, *bit, 1, rtcm_msg_1005->GLO_ind);
+  setbitu(buff, *bit, 1, msg_1005->GLO_ind);
   *bit += 1;
-  setbitu(buff, *bit, 1, rtcm_msg_1005->GAL_ind);
+  setbitu(buff, *bit, 1, msg_1005->GAL_ind);
   *bit += 1;
-  setbitu(buff, *bit, 1, rtcm_msg_1005->ref_stn_ind);
+  setbitu(buff, *bit, 1, msg_1005->ref_stn_ind);
   *bit += 1;
-  setbitsl(buff, *bit, 38, (s64)roundl(rtcm_msg_1005->arp_x * 10000.0));
+  setbitsl(buff, *bit, 38, (s64)roundl(msg_1005->arp_x * 10000.0));
   *bit += 38;
-  setbitu(buff, *bit, 1, rtcm_msg_1005->osc_ind);
+  setbitu(buff, *bit, 1, msg_1005->osc_ind);
   *bit += 1;
   setbitu(buff, *bit, 1, 0);
   *bit += 1;
-  setbitsl(buff, *bit, 38, (s64)roundl(rtcm_msg_1005->arp_y * 10000.0));
+  setbitsl(buff, *bit, 38, (s64)roundl(msg_1005->arp_y * 10000.0));
   *bit += 38;
-  setbitu(buff, *bit, 2, rtcm_msg_1005->quart_cycle_ind);
+  setbitu(buff, *bit, 2, msg_1005->quart_cycle_ind);
   *bit += 2;
-  setbitsl(buff, *bit, 38, (s64)roundl(rtcm_msg_1005->arp_z * 10000.0));
+  setbitsl(buff, *bit, 38, (s64)roundl(msg_1005->arp_z * 10000.0));
   *bit += 38;
 
   /* Round number of bits up to nearest whole byte. */
   return (*bit + 7) / 8;
 }
 
-u16 rtcm3_encode_1005(const rtcm_msg_1005 *rtcm_msg_1005, u8 *buff) {
+u16 rtcm3_encode_1005(const rtcm_msg_1005 *msg_1005, u8 *buff) {
   u16 bit = 0;
   setbitu(buff, bit, 12, 1005);
   bit += 12;
-  return rtcm3_encode_1005_base(rtcm_msg_1005, buff, &bit);
+  return rtcm3_encode_1005_base(msg_1005, buff, &bit);
 }
 
-u16 rtcm3_encode_1006(const rtcm_msg_1006 *rtcm_msg_1006, u8 *buff) {
+u16 rtcm3_encode_1006(const rtcm_msg_1006 *msg_1006, u8 *buff) {
   u16 bit = 0;
   setbitu(buff, bit, 12, 1006);
   bit += 12;
-  rtcm3_encode_1005_base(&rtcm_msg_1006->msg_1005, buff, &bit);
-  setbitu(buff, bit, 16, (u16)roundl(rtcm_msg_1006->ant_height * 10000.0));
+  rtcm3_encode_1005_base(&msg_1006->msg_1005, buff, &bit);
+  setbitu(buff, bit, 16, (u16)roundl(msg_1006->ant_height * 10000.0));
   bit += 16;
 
   /* Round number of bits up to nearest whole byte. */
   return (bit + 7) / 8;
 }
 
-u16 rtcm3_encode_1007_base(const rtcm_msg_1007 *rtcm_msg_1007, u8 *buff,
+u16 rtcm3_encode_1007_base(const rtcm_msg_1007 *msg_1007, u8 *buff,
                            u16 *bit) {
-  setbitu(buff, *bit, 12, rtcm_msg_1007->stn_id);
+  setbitu(buff, *bit, 12, msg_1007->stn_id);
   *bit += 12;
-  setbitu(buff, *bit, 8, rtcm_msg_1007->desc_count);
+  setbitu(buff, *bit, 8, msg_1007->desc_count);
   *bit += 8;
-  for (u8 i = 0; i < rtcm_msg_1007->desc_count; ++i) {
-    setbitu(buff, *bit, 8, rtcm_msg_1007->desc[i]);
+  for (u8 i = 0; i < msg_1007->desc_count; ++i) {
+    setbitu(buff, *bit, 8, msg_1007->desc[i]);
     *bit += 8;
   }
-  setbitu(buff, *bit, 8, rtcm_msg_1007->ant_id);
+  setbitu(buff, *bit, 8, msg_1007->ant_id);
   *bit += 8;
 
   /* Round number of bits up to nearest whole byte. */
   return (*bit + 7) / 8;
 }
 
-u16 rtcm3_encode_1007(const rtcm_msg_1007 *rtcm_msg_1007, u8 *buff) {
+u16 rtcm3_encode_1007(const rtcm_msg_1007 *msg_1007, u8 *buff) {
   u16 bit = 0;
   setbitu(buff, bit, 12, 1007);
   bit += 12;
-  return rtcm3_encode_1007_base(rtcm_msg_1007, buff, &bit);
+  return rtcm3_encode_1007_base(msg_1007, buff, &bit);
 }
 
-u16 rtcm3_encode_1008(const rtcm_msg_1008 *rtcm_msg_1008, u8 *buff) {
+u16 rtcm3_encode_1008(const rtcm_msg_1008 *msg_1008, u8 *buff) {
   u16 bit = 0;
   setbitu(buff, bit, 12, 1008);
   bit += 12;
-  rtcm3_encode_1007_base(&rtcm_msg_1008->msg_1007, buff, &bit);
-  setbitu(buff, bit, 8, rtcm_msg_1008->serial_count);
+  rtcm3_encode_1007_base(&msg_1008->msg_1007, buff, &bit);
+  setbitu(buff, bit, 8, msg_1008->serial_count);
   bit += 8;
-  for (u8 i = 0; i < rtcm_msg_1008->serial_count; ++i) {
-    setbitu(buff, bit, 8, rtcm_msg_1008->serial_num[i]);
+  for (u8 i = 0; i < msg_1008->serial_count; ++i) {
+    setbitu(buff, bit, 8, msg_1008->serial_num[i]);
     bit += 8;
   }
 
@@ -564,27 +671,27 @@ u16 rtcm3_encode_1008(const rtcm_msg_1008 *rtcm_msg_1008, u8 *buff) {
   return (bit + 7) / 8;
 }
 
-s8 rtcm3_decode_1001(const u8 *buff, rtcm_obs_message *rtcm_msg_1001) {
+s8 rtcm3_decode_1001(const u8 *buff, rtcm_obs_message *msg_1001) {
   u16 bit = 0;
-  bit += rtcm3_read_header(buff, &rtcm_msg_1001->header);
+  bit += rtcm3_read_header(buff, &msg_1001->header);
 
-  if (rtcm_msg_1001->header.msg_num != 1001)
+  if (msg_1001->header.msg_num != 1001)
     /* Unexpected message type. */
     return -1;
 
-  for (u8 i = 0; i < rtcm_msg_1001->header.n_sat; i++) {
-    init_data(&rtcm_msg_1001->sats[i]);
+  for (u8 i = 0; i < msg_1001->header.n_sat; i++) {
+    init_data(&msg_1001->sats[i]);
 
     /* TODO: Handle SBAS prns properly, numbered differently in RTCM? */
-    rtcm_msg_1001->sats[i].svId = getbitu(buff, bit, 6);
+    msg_1001->sats[i].svId = getbitu(buff, bit, 6);
     bit += 6;
 
-    rtcm_freq_data *l1_freq_data = &rtcm_msg_1001->sats[i].obs[L1_FREQ];
+    rtcm_freq_data *l1_freq_data = &msg_1001->sats[i].obs[L1_FREQ];
 
     u32 l1_pr;
     s32 phr_pr_diff;
-    s8 rtn = decode_basic_gps_l1_freq_data(buff, &bit, l1_freq_data, &l1_pr,
-                                       &phr_pr_diff);
+    decode_basic_gps_l1_freq_data(buff, &bit, l1_freq_data, &l1_pr,
+                                  &phr_pr_diff);
 
     l1_freq_data->pseudorange = 0.02 * l1_pr;
     l1_freq_data->flags.valid_pr = 1;
@@ -610,27 +717,27 @@ s8 rtcm3_decode_1001(const u8 *buff, rtcm_obs_message *rtcm_msg_1001) {
  *          - `-1` : Message type mismatch
  *          - `-2` : Message uses unsupported P(Y) code
  */
-s8 rtcm3_decode_1002(const u8 *buff, rtcm_obs_message *rtcm_msg_1002) {
+s8 rtcm3_decode_1002(const u8 *buff, rtcm_obs_message *msg_1002) {
   u16 bit = 0;
-  bit += rtcm3_read_header(buff, &rtcm_msg_1002->header);
+  bit += rtcm3_read_header(buff, &msg_1002->header);
 
-  if (rtcm_msg_1002->header.msg_num != 1002)
+  if (msg_1002->header.msg_num != 1002)
     /* Unexpected message type. */
     return -1;
 
-  for (u8 i = 0; i < rtcm_msg_1002->header.n_sat; i++) {
-    init_data(&rtcm_msg_1002->sats[i]);
+  for (u8 i = 0; i < msg_1002->header.n_sat; i++) {
+    init_data(&msg_1002->sats[i]);
 
     /* TODO: Handle SBAS prns properly, numbered differently in RTCM? */
-    rtcm_msg_1002->sats[i].svId = getbitu(buff, bit, 6);
+    msg_1002->sats[i].svId = getbitu(buff, bit, 6);
     bit += 6;
 
-    rtcm_freq_data *l1_freq_data = &rtcm_msg_1002->sats[i].obs[L1_FREQ];
+    rtcm_freq_data *l1_freq_data = &msg_1002->sats[i].obs[L1_FREQ];
 
     u32 l1_pr;
     s32 phr_pr_diff;
-    s8 rtn = decode_basic_gps_l1_freq_data(buff, &bit, l1_freq_data, &l1_pr,
-                                       &phr_pr_diff);
+    decode_basic_gps_l1_freq_data(buff, &bit, l1_freq_data, &l1_pr,
+                                  &phr_pr_diff);
 
     u8 amb = getbitu(buff, bit, 8);
     bit += 8;
@@ -649,28 +756,28 @@ s8 rtcm3_decode_1002(const u8 *buff, rtcm_obs_message *rtcm_msg_1002) {
   return 0;
 }
 
-s8 rtcm3_decode_1003(const u8 *buff, rtcm_obs_message *rtcm_msg_1003) {
+s8 rtcm3_decode_1003(const u8 *buff, rtcm_obs_message *msg_1003) {
   u16 bit = 0;
-  bit += rtcm3_read_header(buff, &rtcm_msg_1003->header);
+  bit += rtcm3_read_header(buff, &msg_1003->header);
 
-  if (rtcm_msg_1003->header.msg_num != 1003)
+  if (msg_1003->header.msg_num != 1003)
     /* Unexpected message type. */
     return -1;
 
-  for (u8 i = 0; i < rtcm_msg_1003->header.n_sat; i++) {
-    init_data(&rtcm_msg_1003->sats[i]);
+  for (u8 i = 0; i < msg_1003->header.n_sat; i++) {
+    init_data(&msg_1003->sats[i]);
 
     /* TODO: Handle SBAS prns properly, numbered differently in RTCM? */
-    rtcm_msg_1003->sats[i].svId = getbitu(buff, bit, 6);
+    msg_1003->sats[i].svId = getbitu(buff, bit, 6);
     bit += 6;
 
-    rtcm_freq_data *l1_freq_data = &rtcm_msg_1003->sats[i].obs[L1_FREQ];
+    rtcm_freq_data *l1_freq_data = &msg_1003->sats[i].obs[L1_FREQ];
 
     u32 l1_pr;
     s32 l2_pr;
     s32 phr_pr_diff;
-    s8 rtn = decode_basic_gps_l1_freq_data(buff, &bit, l1_freq_data, &l1_pr,
-                                       &phr_pr_diff);
+    decode_basic_gps_l1_freq_data(buff, &bit, l1_freq_data, &l1_pr,
+                                  &phr_pr_diff);
 
     l1_freq_data->pseudorange = 0.02 * l1_pr;
     l1_freq_data->flags.valid_pr = 1;
@@ -679,10 +786,10 @@ s8 rtcm3_decode_1003(const u8 *buff, rtcm_obs_message *rtcm_msg_1003) {
         (CLIGHT / GPS_L1_FREQ);
     l1_freq_data->flags.valid_cp = 1;
 
-    rtcm_freq_data *l2_freq_data = &rtcm_msg_1003->sats[i].obs[L2_FREQ];
+    rtcm_freq_data *l2_freq_data = &msg_1003->sats[i].obs[L2_FREQ];
 
-    rtn = decode_basic_l2_freq_data(buff, &bit, l2_freq_data, &l2_pr,
-                                    &phr_pr_diff);
+    decode_basic_l2_freq_data(buff, &bit, l2_freq_data, &l2_pr,
+                              &phr_pr_diff);
 
     l2_freq_data->pseudorange = 0.02 * l2_pr + l1_freq_data->pseudorange;
     l2_freq_data->flags.valid_pr = 1;
@@ -695,28 +802,28 @@ s8 rtcm3_decode_1003(const u8 *buff, rtcm_obs_message *rtcm_msg_1003) {
   return 0;
 }
 
-s8 rtcm3_decode_1004(const u8 *buff, rtcm_obs_message *rtcm_msg_1004) {
+s8 rtcm3_decode_1004(const u8 *buff, rtcm_obs_message *msg_1004) {
   u16 bit = 0;
-  bit += rtcm3_read_header(buff, &rtcm_msg_1004->header);
+  bit += rtcm3_read_header(buff, &msg_1004->header);
 
-  if (rtcm_msg_1004->header.msg_num != 1004)
+  if (msg_1004->header.msg_num != 1004)
     /* Unexpected message type. */
     return -1;
 
-  for (u8 i = 0; i < rtcm_msg_1004->header.n_sat; i++) {
-    init_data(&rtcm_msg_1004->sats[i]);
+  for (u8 i = 0; i < msg_1004->header.n_sat; i++) {
+    init_data(&msg_1004->sats[i]);
 
     /* TODO: Handle SBAS prns properly, numbered differently in RTCM? */
-    rtcm_msg_1004->sats[i].svId = getbitu(buff, bit, 6);
+    msg_1004->sats[i].svId = getbitu(buff, bit, 6);
     bit += 6;
 
-    rtcm_freq_data *l1_freq_data = &rtcm_msg_1004->sats[i].obs[L1_FREQ];
+    rtcm_freq_data *l1_freq_data = &msg_1004->sats[i].obs[L1_FREQ];
 
     u32 l1_pr;
     s32 l2_pr;
     s32 phr_pr_diff;
-    s8 rtn = decode_basic_gps_l1_freq_data(buff, &bit, l1_freq_data, &l1_pr,
-                                       &phr_pr_diff);
+    decode_basic_gps_l1_freq_data(buff, &bit, l1_freq_data, &l1_pr,
+                                  &phr_pr_diff);
 
     u8 amb = getbitu(buff, bit, 8);
     bit += 8;
@@ -731,10 +838,10 @@ s8 rtcm3_decode_1004(const u8 *buff, rtcm_obs_message *rtcm_msg_1004) {
         (CLIGHT / GPS_L1_FREQ);
     l1_freq_data->flags.valid_cp = 1;
 
-    rtcm_freq_data *l2_freq_data = &rtcm_msg_1004->sats[i].obs[L2_FREQ];
+    rtcm_freq_data *l2_freq_data = &msg_1004->sats[i].obs[L2_FREQ];
 
-    rtn = decode_basic_l2_freq_data(buff, &bit, l2_freq_data, &l2_pr,
-                                    &phr_pr_diff);
+    decode_basic_l2_freq_data(buff, &bit, l2_freq_data, &l2_pr,
+                              &phr_pr_diff);
 
     l2_freq_data->cnr = 0.25 * getbitu(buff, bit, 8);
     bit += 8;
@@ -751,37 +858,37 @@ s8 rtcm3_decode_1004(const u8 *buff, rtcm_obs_message *rtcm_msg_1004) {
   return 0;
 }
 
-s8 rtcm3_decode_1005_base(const u8 *buff, rtcm_msg_1005 *rtcm_msg_1005,
+s8 rtcm3_decode_1005_base(const u8 *buff, rtcm_msg_1005 *msg_1005,
                           u16 *bit) {
-  rtcm_msg_1005->stn_id = getbitu(buff, *bit, 12);
+  msg_1005->stn_id = getbitu(buff, *bit, 12);
   *bit += 12;
-  rtcm_msg_1005->ITRF = getbitu(buff, *bit, 6);
+  msg_1005->ITRF = getbitu(buff, *bit, 6);
   *bit += 6;
-  rtcm_msg_1005->GPS_ind = getbitu(buff, *bit, 1);
+  msg_1005->GPS_ind = getbitu(buff, *bit, 1);
   *bit += 1;
-  rtcm_msg_1005->GLO_ind = getbitu(buff, *bit, 1);
+  msg_1005->GLO_ind = getbitu(buff, *bit, 1);
   *bit += 1;
-  rtcm_msg_1005->GAL_ind = getbitu(buff, *bit, 1);
+  msg_1005->GAL_ind = getbitu(buff, *bit, 1);
   *bit += 1;
-  rtcm_msg_1005->ref_stn_ind = getbitu(buff, *bit, 1);
+  msg_1005->ref_stn_ind = getbitu(buff, *bit, 1);
   *bit += 1;
-  rtcm_msg_1005->arp_x = (double)(getbitsl(buff, *bit, 38)) / 10000.0;
+  msg_1005->arp_x = (double)(getbitsl(buff, *bit, 38)) / 10000.0;
   *bit += 38;
-  rtcm_msg_1005->osc_ind = getbitu(buff, *bit, 1);
+  msg_1005->osc_ind = getbitu(buff, *bit, 1);
   *bit += 1;
   getbitu(buff, *bit, 1);
   *bit += 1;
-  rtcm_msg_1005->arp_y = (double)(getbitsl(buff, *bit, 38)) / 10000.0;
+  msg_1005->arp_y = (double)(getbitsl(buff, *bit, 38)) / 10000.0;
   *bit += 38;
-  rtcm_msg_1005->quart_cycle_ind = getbitu(buff, *bit, 2);
+  msg_1005->quart_cycle_ind = getbitu(buff, *bit, 2);
   *bit += 2;
-  rtcm_msg_1005->arp_z = (double)(getbitsl(buff, *bit, 38)) / 10000.0;
+  msg_1005->arp_z = (double)(getbitsl(buff, *bit, 38)) / 10000.0;
   *bit += 38;
 
   return 0;
 }
 
-s8 rtcm3_decode_1005(const u8 *buff, rtcm_msg_1005 *rtcm_msg_1005) {
+s8 rtcm3_decode_1005(const u8 *buff, rtcm_msg_1005 *msg_1005) {
   u16 bit = 0;
   u16 msg_num = getbitu(buff, bit, 12);
   bit += 12;
@@ -790,10 +897,10 @@ s8 rtcm3_decode_1005(const u8 *buff, rtcm_msg_1005 *rtcm_msg_1005) {
     /* Unexpected message type. */
     return -1;
 
-  return rtcm3_decode_1005_base(buff, rtcm_msg_1005, &bit);
+  return rtcm3_decode_1005_base(buff, msg_1005, &bit);
 }
 
-s8 rtcm3_decode_1006(const u8 *buff, rtcm_msg_1006 *rtcm_msg_1006) {
+s8 rtcm3_decode_1006(const u8 *buff, rtcm_msg_1006 *msg_1006) {
   u16 bit = 0;
   u16 msg_num = getbitu(buff, bit, 12);
   bit += 12;
@@ -802,29 +909,29 @@ s8 rtcm3_decode_1006(const u8 *buff, rtcm_msg_1006 *rtcm_msg_1006) {
     /* Unexpected message type. */
     return -1;
 
-  rtcm3_decode_1005_base(buff, &rtcm_msg_1006->msg_1005, &bit);
-  rtcm_msg_1006->ant_height = (double)(getbitu(buff, bit, 16)) / 10000.0;
+  rtcm3_decode_1005_base(buff, &msg_1006->msg_1005, &bit);
+  msg_1006->ant_height = (double)(getbitu(buff, bit, 16)) / 10000.0;
   bit += 16;
   return 0;
 }
 
-s8 rtcm3_decode_1007_base(const u8 *buff, rtcm_msg_1007 *rtcm_msg_1007,
+s8 rtcm3_decode_1007_base(const u8 *buff, rtcm_msg_1007 *msg_1007,
                           u16 *bit) {
-  rtcm_msg_1007->stn_id = getbitu(buff, *bit, 12);
+  msg_1007->stn_id = getbitu(buff, *bit, 12);
   *bit += 12;
-  rtcm_msg_1007->desc_count = getbitu(buff, *bit, 8);
+  msg_1007->desc_count = getbitu(buff, *bit, 8);
   *bit += 8;
-  for (u8 i = 0; i < rtcm_msg_1007->desc_count; ++i) {
-    rtcm_msg_1007->desc[i] = getbitu(buff, *bit, 8);
+  for (u8 i = 0; i < msg_1007->desc_count; ++i) {
+    msg_1007->desc[i] = getbitu(buff, *bit, 8);
     *bit += 8;
   }
-  rtcm_msg_1007->ant_id = getbitu(buff, *bit, 8);
+  msg_1007->ant_id = getbitu(buff, *bit, 8);
   *bit += 8;
 
   return 0;
 }
 
-s8 rtcm3_decode_1007(const u8 *buff, rtcm_msg_1007 *rtcm_msg_1007) {
+s8 rtcm3_decode_1007(const u8 *buff, rtcm_msg_1007 *msg_1007) {
   u16 bit = 0;
   u16 msg_num = getbitu(buff, bit, 12);
   bit += 12;
@@ -833,12 +940,12 @@ s8 rtcm3_decode_1007(const u8 *buff, rtcm_msg_1007 *rtcm_msg_1007) {
     /* Unexpected message type. */
     return -1;
 
-  rtcm3_decode_1007_base(buff, rtcm_msg_1007, &bit);
+  rtcm3_decode_1007_base(buff, msg_1007, &bit);
 
   return 0;
 }
 
-s8 rtcm3_decode_1008(const u8 *buff, rtcm_msg_1008 *rtcm_msg_1008) {
+s8 rtcm3_decode_1008(const u8 *buff, rtcm_msg_1008 *msg_1008) {
   u16 bit = 0;
   u16 msg_num = getbitu(buff, bit, 12);
   bit += 12;
@@ -847,36 +954,36 @@ s8 rtcm3_decode_1008(const u8 *buff, rtcm_msg_1008 *rtcm_msg_1008) {
     /* Unexpected message type. */
     return -1;
 
-  rtcm3_decode_1007_base(buff, &rtcm_msg_1008->msg_1007, &bit);
-  rtcm_msg_1008->serial_count = getbitu(buff, bit, 8);
+  rtcm3_decode_1007_base(buff, &msg_1008->msg_1007, &bit);
+  msg_1008->serial_count = getbitu(buff, bit, 8);
   bit += 8;
-  for (u8 i = 0; i < rtcm_msg_1008->serial_count; ++i) {
-    rtcm_msg_1008->serial_num[i] = getbitu(buff, bit, 8);
+  for (u8 i = 0; i < msg_1008->serial_count; ++i) {
+    msg_1008->serial_num[i] = getbitu(buff, bit, 8);
     bit += 8;
   }
   return 0;
 }
 
-s8 rtcm3_decode_1010(const u8 *buff, rtcm_obs_message *rtcm_msg_1010) {
+s8 rtcm3_decode_1010(const u8 *buff, rtcm_obs_message *msg_1010) {
   u16 bit = 0;
-  bit += rtcm3_read_glo_header(buff, &rtcm_msg_1010->header);
+  bit += rtcm3_read_glo_header(buff, &msg_1010->header);
 
-  if (rtcm_msg_1010->header.msg_num != 1010)
+  if (msg_1010->header.msg_num != 1010)
     /* Unexpected message type. */
     return -1;
 
-  for (u8 i = 0; i < rtcm_msg_1010->header.n_sat; i++) {
-    init_data(&rtcm_msg_1010->sats[i]);
+  for (u8 i = 0; i < msg_1010->header.n_sat; i++) {
+    init_data(&msg_1010->sats[i]);
 
-    rtcm_msg_1010->sats[i].svId = getbitu(buff, bit, 6);
+    msg_1010->sats[i].svId = getbitu(buff, bit, 6);
     bit += 6;
 
-    rtcm_freq_data *l1_freq_data = &rtcm_msg_1010->sats[i].obs[L1_FREQ];
+    rtcm_freq_data *l1_freq_data = &msg_1010->sats[i].obs[L1_FREQ];
 
     u32 l1_pr;
     s32 phr_pr_diff;
-    s8 rtn = decode_basic_glo_l1_freq_data(buff, &bit, l1_freq_data, &l1_pr,
-                                       &phr_pr_diff);
+    decode_basic_glo_l1_freq_data(buff, &bit, l1_freq_data, &l1_pr,
+                                  &phr_pr_diff);
 
     u8 amb = getbitu(buff, bit, 7);
     bit += 7;
@@ -896,28 +1003,28 @@ s8 rtcm3_decode_1010(const u8 *buff, rtcm_obs_message *rtcm_msg_1010) {
   return 0;
 }
 
-s8 rtcm3_decode_1012(const u8 *buff, rtcm_obs_message *rtcm_msg_1012) {
+s8 rtcm3_decode_1012(const u8 *buff, rtcm_obs_message *msg_1012) {
   u16 bit = 0;
-  bit += rtcm3_read_header(buff, &rtcm_msg_1012->header);
+  bit += rtcm3_read_header(buff, &msg_1012->header);
 
-  if (rtcm_msg_1012->header.msg_num != 1012)
+  if (msg_1012->header.msg_num != 1012)
     /* Unexpected message type. */
     return -1;
 
-  for (u8 i = 0; i < rtcm_msg_1012->header.n_sat; i++) {
-    init_data(&rtcm_msg_1012->sats[i]);
+  for (u8 i = 0; i < msg_1012->header.n_sat; i++) {
+    init_data(&msg_1012->sats[i]);
 
     /* TODO: Handle SBAS prns properly, numbered differently in RTCM? */
-    rtcm_msg_1012->sats[i].svId = getbitu(buff, bit, 6);
+    msg_1012->sats[i].svId = getbitu(buff, bit, 6);
     bit += 6;
 
-    rtcm_freq_data *l1_freq_data = &rtcm_msg_1012->sats[i].obs[L1_FREQ];
+    rtcm_freq_data *l1_freq_data = &msg_1012->sats[i].obs[L1_FREQ];
 
     u32 l1_pr;
     s32 l2_pr;
     s32 phr_pr_diff;
-    s8 rtn = decode_basic_glo_l1_freq_data(buff, &bit, l1_freq_data, &l1_pr,
-                                       &phr_pr_diff);
+    decode_basic_glo_l1_freq_data(buff, &bit, l1_freq_data, &l1_pr,
+                                  &phr_pr_diff);
 
     u8 amb = getbitu(buff, bit, 8);
     bit += 8;
@@ -933,9 +1040,9 @@ s8 rtcm3_decode_1012(const u8 *buff, rtcm_obs_message *rtcm_msg_1012) {
       (CLIGHT / (GLO_L1_FREQ + glo_fcn * GLO_L1_CH_OFFSET));
     l1_freq_data->flags.valid_cp = 1;
 
-    rtcm_freq_data *l2_freq_data = &rtcm_msg_1012->sats[i].obs[L2_FREQ];
+    rtcm_freq_data *l2_freq_data = &msg_1012->sats[i].obs[L2_FREQ];
 
-    rtn = decode_basic_l2_freq_data(buff, &bit, l2_freq_data, &l2_pr,
+    decode_basic_l2_freq_data(buff, &bit, l2_freq_data, &l2_pr,
                                     &phr_pr_diff);
 
     l2_freq_data->cnr = 0.25 * getbitu(buff, bit, 8);
@@ -953,116 +1060,3 @@ s8 rtcm3_decode_1012(const u8 *buff, rtcm_obs_message *rtcm_msg_1012) {
   return 0;
 }
 
-void encode_basic_freq_data(const rtcm_freq_data *freq_data, const double freq,
-                          const double *l1_pr, u8 *buff, u16 *bit) {
-
-  /* Calculate GPS Integer L1 Pseudorange Modulus Ambiguity (DF014). */
-  u8 amb = (u8)(*l1_pr / PRUNIT_GPS);
-
-  /* Construct L1 pseudorange value as it would be transmitted (DF011). */
-  u32 calc_l1_pr = (u32)roundl((double)(*l1_pr - amb * PRUNIT_GPS) / 0.02);
-
-  /* Calculate GPS Pseudorange (DF011/DF016). */
-  u32 pr = (u32)roundl((freq_data->pseudorange - amb * PRUNIT_GPS) / 0.02);
-
-  double l1_prc = calc_l1_pr * 0.02 + amb * PRUNIT_GPS;
-
-  /* phaserange - L1 pseudorange */
-  double cp_pr = freq_data->carrier_phase - l1_prc / (CLIGHT / freq);
-
-  // pgrgich: TO DO!!
-  //  /* If the phaserange and pseudorange have diverged close to the limits of
-  //  the
-  //   * data field (20 bits) then we modify the carrier phase by an integer
-  //   amount
-  //   * to bring it back into range an reset the phase lock time to zero to
-  //   reset
-  //   * the integer ambiguity.
-  //   * The spec suggests adjusting by 1500 cycles but I calculate the range to
-  //   be
-  //   * +/- 1379 cycles. Limit to just 1000 as that should still be plenty. */
-  //  if (fabs(cp_pr) > 1000) {
-  //    nm->lock_time = 0;
-  //    nm->raw_carrier_phase -= (s32)cp_pr;
-  //    cp_pr -= (s32)cp_pr;
-  //  }
-
-  /* Calculate GPS PhaseRange – L1 Pseudorange (DF012/DF018). */
-  s32 ppr = roundl(cp_pr * (CLIGHT / freq) / 0.0005);
-
-  if (freq == GPS_L1_FREQ) {
-    setbitu(buff, *bit, 1, 0);
-    *bit += 1;
-    setbitu(buff, *bit, 24, pr);
-    *bit += 24;
-  } else {
-    setbitu(buff, *bit, 2, 0);
-    *bit += 2;
-    setbits(buff, *bit, 14, (s32)pr - (s32)calc_l1_pr);
-    *bit += 14;
-  }
-  setbits(buff, *bit, 20, ppr);
-  *bit += 20;
-  setbitu(buff, *bit, 7,
-          freq_data->flags.valid_lock ? to_lock_ind(freq_data->lock) : 0);
-  *bit += 7;
-}
-
-s8 decode_basic_gps_l1_freq_data(const u8 *buff, u16 *bit,
-                                 rtcm_freq_data *freq_data, u32 *pr,
-                                 s32 *phr_pr_diff) {
-  freq_data->code = getbitu(buff, *bit, 1);
-  *bit += 1;
-  *pr = getbitu(buff, *bit, 24);
-  *bit += 24;
-  *phr_pr_diff = getbits(buff, *bit, 20);
-  *bit += 20;
-
-  freq_data->lock = from_lock_ind(getbitu(buff, *bit, 7));
-  *bit += 7;
-  freq_data->flags.valid_lock = 1;
-
-  return 0;
-}
-
-s8 decode_basic_glo_l1_freq_data(const u8 *buff, u16 *bit,
-                                 rtcm_freq_data *freq_data, u32 *pr,
-                                 s32 *phr_pr_diff) {
-  freq_data->code = getbitu(buff, *bit, 1);
-  *bit += 1;
-  freq_data->fcn = getbitu(buff, *bit, 5);
-  *bit += 5;
-  *pr = getbitu(buff, *bit, 25);
-  *bit += 25;
-  *phr_pr_diff = getbits(buff, *bit, 20);
-  *bit += 20;
-
-  freq_data->lock = from_lock_ind(getbitu(buff, *bit, 7));
-  *bit += 7;
-  freq_data->flags.valid_lock = 1;
-
-  return 0;
-}
-
-s8 decode_basic_l2_freq_data(const u8 *buff, u16 *bit,
-                             rtcm_freq_data *freq_data, s32 *pr,
-                             s32 *phr_pr_diff) {
-  freq_data->code = getbitu(buff, *bit, 2);
-  *bit += 2;
-  *pr = getbits(buff, *bit, 14);
-  *bit += 14;
-  *phr_pr_diff = getbits(buff, *bit, 20);
-  *bit += 20;
-
-  freq_data->lock = from_lock_ind(getbitu(buff, *bit, 7));
-  *bit += 7;
-  freq_data->flags.valid_lock = 1;
-
-  return 0;
-}
-
-void init_data(rtcm_sat_data *sat_data) {
-  for (u8 freq = 0; freq < NUM_FREQS; ++freq) {
-    sat_data->obs[freq].flags.data = 0;
-  }
-}

--- a/c/src/rtcm3_decode.c
+++ b/c/src/rtcm3_decode.c
@@ -1,0 +1,1068 @@
+/*
+ * Copyright (C) 2017 Swift Navigation Inc.
+ * Contact: Jacob McNamee <jacob@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+// pgrgich: need to handle invalid obs...
+
+#include "rtcm3_decode.h"
+#include "rtcm3_messages.h"
+#include <math.h>
+
+/** Get bit field from buffer as an unsigned integer.
+ * Unpacks `len` bits at bit position `pos` from the start of the buffer.
+ * Maximum bit field length is 32 bits, i.e. `len <= 32`.
+ *
+ * \param buff
+ * \param pos Position in buffer of start of bit field in bits.
+ * \param len Length of bit field in bits.
+ * \return Bit field as an unsigned value.
+ */
+u32 getbitu(const u8 *buff, u32 pos, u8 len) {
+  u32 bits = 0;
+
+  for (u32 i = pos; i < pos + len; i++) {
+    bits = (bits << 1) + ((buff[i / 8] >> (7 - i % 8)) & 1u);
+  }
+
+  return bits;
+}
+
+/** Get bit field from buffer as an unsigned integer.
+ * Unpacks `len` bits at bit position `pos` from the start of the buffer.
+ * Maximum bit field length is 32 bits, i.e. `len <= 32`.
+ *
+ * \param buff
+ * \param pos Position in buffer of start of bit field in bits.
+ * \param len Length of bit field in bits.
+ * \return Bit field as an unsigned value.
+ */
+u64 getbitul(const u8 *buff, u32 pos, u8 len) {
+  u64 bits = 0;
+
+  for (u32 i = pos; i < pos + len; i++) {
+    bits = (bits << 1) + ((buff[i / 8] >> (7 - i % 8)) & 1u);
+  }
+
+  return bits;
+}
+
+/** Get bit field from buffer as a signed integer.
+ * Unpacks `len` bits at bit position `pos` from the start of the buffer.
+ * Maximum bit field length is 32 bits, i.e. `len <= 32`.
+ *
+ * This function sign extends the `len` bit field to a signed 32 bit integer.
+ *
+ * \param buff
+ * \param pos Position in buffer of start of bit field in bits.
+ * \param len Length of bit field in bits.
+ * \return Bit field as a signed value.
+ */
+s32 getbits(const u8 *buff, u32 pos, u8 len) {
+  s32 bits = (s32)getbitu(buff, pos, len);
+
+  /* Sign extend, taken from:
+   * http://graphics.stanford.edu/~seander/bithacks.html#VariableSignExtend
+   */
+  s32 m = 1u << (len - 1);
+  return (bits ^ m) - m;
+}
+
+/** Get bit field from buffer as a signed integer.
+ * Unpacks `len` bits at bit position `pos` from the start of the buffer.
+ * Maximum bit field length is 64 bits, i.e. `len <= 64`.
+ *
+ * This function sign extends the `len` bit field to a signed 64 bit integer.
+ *
+ * \param buff
+ * \param pos Position in buffer of start of bit field in bits.
+ * \param len Length of bit field in bits.
+ * \return Bit field as a signed value.
+ */
+s64 getbitsl(const u8 *buff, u32 pos, u8 len) {
+  s64 bits = (s64)getbitul(buff, pos, len);
+
+  /* Sign extend, taken from:
+   * http://graphics.stanford.edu/~seander/bithacks.html#VariableSignExtend
+   */
+  s64 m = ((u64)1) << (len - 1);
+  return (bits ^ m) - m;
+}
+
+/** Set bit field in buffer from an unsigned integer.
+ * Packs `len` bits into bit position `pos` from the start of the buffer.
+ * Maximum bit field length is 32 bits, i.e. `len <= 32`.
+ *
+ * \param buff
+ * \param pos Position in buffer of start of bit field in bits.
+ * \param len Length of bit field in bits.
+ * \param data Unsigned integer to be packed into bit field.
+ */
+void setbitu(u8 *buff, u32 pos, u32 len, u32 data) {
+  u32 mask = 1u << (len - 1);
+
+  if (len <= 0 || 32 < len)
+    return;
+
+  for (u32 i = pos; i < pos + len; i++, mask >>= 1) {
+    if (data & mask)
+      buff[i / 8] |= 1u << (7 - i % 8);
+    else
+      buff[i / 8] &= ~(1u << (7 - i % 8));
+  }
+}
+
+/** Set bit field in buffer from an unsigned integer.
+ * Packs `len` bits into bit position `pos` from the start of the buffer.
+ * Maximum bit field length is 32 bits, i.e. `len <= 32`.
+ *
+ * \param buff
+ * \param pos Position in buffer of start of bit field in bits.
+ * \param len Length of bit field in bits.
+ * \param data Unsigned integer to be packed into bit field.
+ */
+void setbitul(u8 *buff, u32 pos, u32 len, u64 data) {
+  u64 mask = ((u64)1) << (len - 1);
+
+  if (len <= 0 || 64 < len)
+    return;
+
+  for (u32 i = pos; i < pos + len; i++, mask >>= 1) {
+    if (data & mask)
+      buff[i / 8] |= ((u64)1) << (7 - i % 8);
+    else
+      buff[i / 8] &= ~(((u64)1) << (7 - i % 8));
+  }
+}
+
+/** Set bit field in buffer from a signed integer.
+ * Packs `len` bits into bit position `pos` from the start of the buffer.
+ * Maximum bit field length is 32 bits, i.e. `len <= 32`.
+ *
+ * \param buff
+ * \param pos Position in buffer of start of bit field in bits.
+ * \param len Length of bit field in bits.
+ * \param data Signed integer to be packed into bit field.
+ */
+void setbits(u8 *buff, u32 pos, u32 len, s32 data) {
+  setbitu(buff, pos, len, (u32)data);
+}
+
+/** Set bit field in buffer from a signed integer.
+ * Packs `len` bits into bit position `pos` from the start of the buffer.
+ * Maximum bit field length is 32 bits, i.e. `len <= 32`.
+ *
+ * \param buff
+ * \param pos Position in buffer of start of bit field in bits.
+ * \param len Length of bit field in bits.
+ * \param data Signed integer to be packed into bit field.
+ */
+void setbitsl(u8 *buff, u32 pos, u32 len, s64 data) {
+  setbitul(buff, pos, len, (u64)data);
+}
+
+/** Write RTCM header for observation message types 1001..1004.
+ *
+ * The data message header will be written starting from byte zero of the
+ * buffer. If the buffer also contains a frame header then be sure to pass a
+ * pointer to the start of the data message rather than a pointer to the start
+ * of the frame buffer. The RTCM observation header is 8 bytes (64 bits) long.
+ *
+ * If the Synchronous GNSS Message Flag is set to `0`, it means that no further
+ * GNSS observables referenced to the same Epoch Time will be transmitted. This
+ * enables the receiver to begin processing the data immediately after decoding
+ * the message. If it is set to `1`, it means that the next message will
+ * contain observables of another GNSS source referenced to the same Epoch
+ * Time.
+ *
+ * Divergence-free Smoothing Indicator values:
+ *
+ * Indicator | Meaning
+ * --------- | ----------------------------------
+ *     0     | Divergence-free smoothing not used
+ *     1     | Divergence-free smoothing used
+ *
+ * GPS Smoothing Interval indicator values are listed in RTCM 10403.1 Table
+ * 3.4-4, reproduced here:
+ *
+ * Indicator | Smoothing Interval
+ * --------- | ------------------
+ *  000 (0)  |   No smoothing
+ *  001 (1)  |   < 30 s
+ *  010 (2)  |   30-60 s
+ *  011 (3)  |   1-2 min
+ *  100 (4)  |   2-4 min
+ *  101 (5)  |   4-8 min
+ *  110 (6)  |   >8 min
+ *  111 (7)  |   Unlimited
+ *
+ * \param buff A pointer to the RTCM data message buffer.
+ * \param type Message type number, i.e. 1001..1004 (DF002).
+ * \param id Reference station ID (DF003).
+ * \param t GPS time of epoch (DF004).
+ * \param sync Synchronous GNSS Flag (DF005).
+ * \param n_sat Number of GPS satellites included in the message (DF006).
+ * \param div_free GPS Divergence-free Smoothing Indicator (DF007).
+ * \param smooth GPS Smoothing Interval indicator (DF008).
+ */
+u16 rtcm3_write_header(const rtcm_obs_header *header, u8 num_sats, u8 *buff) {
+  u16 bit = 0;
+  setbitu(buff, bit, 12, header->msg_num);
+  bit += 12;
+  setbitu(buff, bit, 12, header->stn_id);
+  bit += 12;
+  setbitu(buff, bit, 30, (u32)round(header->tow * 1e3));
+  bit += 30;
+  setbitu(buff, bit, 1, header->sync);
+  bit += 1;
+  setbitu(buff, bit, 5, num_sats);
+  bit += 5;
+  setbitu(buff, bit, 1, header->div_free);
+  bit += 1;
+  setbitu(buff, bit, 3, header->smooth);
+  bit += 3;
+  return bit;
+}
+
+/** Read RTCM header for observation message types 1001..1004.
+ *
+ * The data message header will be read starting from byte zero of the
+ * buffer. If the buffer also contains a frame header then be sure to pass a
+ * pointer to the start of the data message rather than a pointer to the start
+ * of the frame buffer. The RTCM observation header is 8 bytes (64 bits) long.
+ *
+ * All return values are written into the parameters passed by reference.
+ *
+ * \param buff A pointer to the RTCM data message buffer.
+ * \param type Message type number, i.e. 1001..1004 (DF002).
+ * \param id Reference station ID (DF003).
+ * \param tow GPS time of week of the epoch (DF004).
+ * \param sync Synchronous GNSS Flag (DF005).
+ * \param n_sat Number of GPS satellites included in the message (DF006).
+ * \param div_free GPS Divergence-free Smoothing Indicator (DF007).
+ * \param smooth GPS Smoothing Interval indicator (DF008).
+ */
+u16 rtcm3_read_header(const u8 *buff, rtcm_obs_header *header) {
+  u16 bit = 0;
+  header->msg_num = getbitu(buff, bit, 12);
+  bit += 12;
+  header->stn_id = getbitu(buff, bit, 12);
+  bit += 12;
+  header->tow = getbitu(buff, bit, 30) / 1e3;
+  bit += 30;
+  header->sync = getbitu(buff, bit, 1);
+  bit += 1;
+  header->n_sat = getbitu(buff, bit, 5);
+  bit += 5;
+  header->div_free = getbitu(buff, bit, 1);
+  bit += 1;
+  header->smooth = getbitu(buff, bit, 3);
+  bit += 3;
+  return bit;
+}
+
+/** Read RTCM header for observation message types 1009..1012.
+ *
+ * The data message header will be read starting from byte zero of the
+ * buffer. If the buffer also contains a frame header then be sure to pass a
+ * pointer to the start of the data message rather than a pointer to the start
+ * of the frame buffer. The RTCM observation header is 8 bytes (64 bits) long.
+ *
+ */
+u16 rtcm3_read_glo_header(const u8 *buff, rtcm_obs_header *header) {
+  u16 bit = 0;
+  header->msg_num = getbitu(buff, bit, 12);
+  bit += 12;
+  header->stn_id = getbitu(buff, bit, 12);
+  bit += 12;
+  header->tow = getbitu(buff, bit, 27) / 1e3;
+  bit += 27;
+  header->sync = getbitu(buff, bit, 1);
+  bit += 1;
+  header->n_sat = getbitu(buff, bit, 5);
+  bit += 5;
+  header->div_free = getbitu(buff, bit, 1);
+  bit += 1;
+  header->smooth = getbitu(buff, bit, 3);
+  bit += 3;
+  return bit;
+}
+
+/** Convert a lock time in seconds into a RTCMv3 Lock Time Indicator value.
+ * See RTCM 10403.1, Table 3.4-2.
+ *
+ * \param time Lock time in seconds.
+ * \return Lock Time Indicator value.
+ */
+static u8 to_lock_ind(u32 time) {
+  if (time < 24)
+    return time;
+  if (time < 72)
+    return (time + 24) / 2;
+  if (time < 168)
+    return (time + 120) / 4;
+  if (time < 360)
+    return (time + 408) / 8;
+  if (time < 744)
+    return (time + 1176) / 16;
+  if (time < 937)
+    return (time + 3096) / 32;
+  return 127;
+}
+
+/** Convert a RTCMv3 Lock Time Indicator value into a minimum lock time in
+ * seconds.
+ * See RTCM 10403.1, Table 3.4-2.
+ *
+ * \param lock Lock Time Indicator value.
+ * \return Minimum lock time in seconds.
+ */
+static u32 from_lock_ind(u8 lock) {
+  if (lock < 24)
+    return lock;
+  if (lock < 48)
+    return 2 * lock - 24;
+  if (lock < 72)
+    return 4 * lock - 120;
+  if (lock < 96)
+    return 8 * lock - 408;
+  if (lock < 120)
+    return 16 * lock - 1176;
+  if (lock < 127)
+    return 32 * lock - 3096;
+  return 937;
+}
+
+u16 rtcm3_encode_1001(const rtcm_obs_message *rtcm_msg_1001, u8 *buff) {
+  u16 bit = 64; /* Start at end of header. */
+
+  u8 num_sats = 0;
+  for (u8 i = 0; i < rtcm_msg_1001->header.n_sat; i++) {
+    if (rtcm_msg_1001->sats[i].obs[L1_FREQ].flags.valid_pr &&
+        rtcm_msg_1001->sats[i].obs[L1_FREQ].flags.valid_cp) {
+      setbitu(buff, bit, 6, rtcm_msg_1001->sats[i].svId);
+      bit += 6;
+      encode_basic_freq_data(&rtcm_msg_1001->sats[i].obs[L1_FREQ], GPS_L1_FREQ,
+                             &rtcm_msg_1001->sats[i].obs[L1_FREQ].pseudorange,
+                             buff, &bit);
+      ++num_sats;
+    }
+  }
+
+  rtcm3_write_header(&rtcm_msg_1001->header, num_sats, buff);
+
+  /* Round number of bits up to nearest whole byte. */
+  return (bit + 7) / 8;
+}
+
+/** Encode an RTCMv3 message type 1002 (Extended L1-Only GPS RTK Observables)
+ * Message type 1002 has length `64 + n_sat*74` bits. Returned message length
+ * is rounded up to the nearest whole byte.
+ *
+ * \param buff A pointer to the RTCM data message buffer.
+ * \param id Reference station ID (DF003).
+ * \param t GPS time of epoch (DF004).
+ * \param n_sat Number of GPS satellites included in the message (DF006).
+ * \param nm Struct containing the observation.
+ * \param sync Synchronous GNSS Flag (DF005).
+ * \return The message length in bytes.
+ */
+u16 rtcm3_encode_1002(const rtcm_obs_message *rtcm_msg_1002, u8 *buff) {
+  u16 bit = 64; /* Start at end of header. */
+
+  u8 num_sats = 0;
+  for (u8 i = 0; i < rtcm_msg_1002->header.n_sat; i++) {
+    if (rtcm_msg_1002->sats[i].obs[L1_FREQ].flags.valid_pr &&
+        rtcm_msg_1002->sats[i].obs[L1_FREQ].flags.valid_cp) {
+      setbitu(buff, bit, 6, rtcm_msg_1002->sats[i].svId);
+      bit += 6;
+      encode_basic_freq_data(&rtcm_msg_1002->sats[i].obs[L1_FREQ], GPS_L1_FREQ,
+                             &rtcm_msg_1002->sats[i].obs[L1_FREQ].pseudorange,
+                             buff, &bit);
+
+      /* Calculate GPS Integer L1 Pseudorange Modulus Ambiguity (DF014). */
+      u8 amb =
+          (u8)(rtcm_msg_1002->sats[i].obs[L1_FREQ].pseudorange / PRUNIT_GPS);
+
+      setbitu(buff, bit, 8, amb);
+      bit += 8;
+      setbitu(buff, bit, 8,
+              (u8)roundl(rtcm_msg_1002->sats[i].obs[L1_FREQ].cnr * 4.0));
+      bit += 8;
+      ++num_sats;
+    }
+  }
+
+  rtcm3_write_header(&rtcm_msg_1002->header, num_sats, buff);
+
+  /* Round number of bits up to nearest whole byte. */
+  return (bit + 7) / 8;
+}
+
+u16 rtcm3_encode_1003(const rtcm_obs_message *rtcm_msg_1003, u8 *buff) {
+  u16 bit = 64; /* Start at end of header. */
+
+  u8 num_sats = 0;
+  for (u8 i = 0; i < rtcm_msg_1003->header.n_sat; i++) {
+    flag_bf l1_flags = rtcm_msg_1003->sats[i].obs[L1_FREQ].flags;
+    flag_bf l2_flags = rtcm_msg_1003->sats[i].obs[L2_FREQ].flags;
+    if (l1_flags.valid_pr && l1_flags.valid_cp && l2_flags.valid_pr &&
+        l2_flags.valid_cp) {
+      setbitu(buff, bit, 6, rtcm_msg_1003->sats[i].svId);
+      bit += 6;
+      encode_basic_freq_data(&rtcm_msg_1003->sats[i].obs[L1_FREQ], GPS_L1_FREQ,
+                             &rtcm_msg_1003->sats[i].obs[L1_FREQ].pseudorange,
+                             buff, &bit);
+      encode_basic_freq_data(&rtcm_msg_1003->sats[i].obs[L2_FREQ], GPS_L2_FREQ,
+                             &rtcm_msg_1003->sats[i].obs[L1_FREQ].pseudorange,
+                             buff, &bit);
+      ++num_sats;
+    }
+  }
+
+  rtcm3_write_header(&rtcm_msg_1003->header, num_sats, buff);
+
+  /* Round number of bits up to nearest whole byte. */
+  return (bit + 7) / 8;
+}
+
+u16 rtcm3_encode_1004(const rtcm_obs_message *rtcm_msg_1004, u8 *buff) {
+  u16 bit = 64; /* Start at end of header. */
+
+  u8 num_sats = 0;
+  for (u8 i = 0; i < rtcm_msg_1004->header.n_sat; i++) {
+    flag_bf l1_flags = rtcm_msg_1004->sats[i].obs[L1_FREQ].flags;
+    flag_bf l2_flags = rtcm_msg_1004->sats[i].obs[L2_FREQ].flags;
+    if (l1_flags.valid_pr && l1_flags.valid_cp && l2_flags.valid_pr &&
+        l2_flags.valid_cp) {
+      setbitu(buff, bit, 6, rtcm_msg_1004->sats[i].svId);
+      bit += 6;
+      encode_basic_freq_data(&rtcm_msg_1004->sats[i].obs[L1_FREQ], GPS_L1_FREQ,
+                             &rtcm_msg_1004->sats[i].obs[L1_FREQ].pseudorange,
+                             buff, &bit);
+
+      /* Calculate GPS Integer L1 Pseudorange Modulus Ambiguity (DF014). */
+      u8 amb =
+          (u8)(rtcm_msg_1004->sats[i].obs[L1_FREQ].pseudorange / PRUNIT_GPS);
+
+      setbitu(buff, bit, 8, amb);
+      bit += 8;
+      setbitu(buff, bit, 8,
+              (u8)roundl(rtcm_msg_1004->sats[i].obs[L1_FREQ].cnr * 4.0));
+      bit += 8;
+
+      encode_basic_freq_data(&rtcm_msg_1004->sats[i].obs[L2_FREQ], GPS_L2_FREQ,
+                             &rtcm_msg_1004->sats[i].obs[L1_FREQ].pseudorange,
+                             buff, &bit);
+      setbitu(buff, bit, 8,
+              (u8)roundl(rtcm_msg_1004->sats[i].obs[L2_FREQ].cnr * 4.0));
+      bit += 8;
+      ++num_sats;
+    }
+  }
+
+  rtcm3_write_header(&rtcm_msg_1004->header, num_sats, buff);
+
+  /* Round number of bits up to nearest whole byte. */
+  return (bit + 7) / 8;
+}
+
+u16 rtcm3_encode_1005_base(const rtcm_msg_1005 *rtcm_msg_1005, u8 *buff,
+                           u16 *bit) {
+  setbitu(buff, *bit, 12, rtcm_msg_1005->stn_id);
+  *bit += 12;
+  setbitu(buff, *bit, 6, rtcm_msg_1005->ITRF);
+  *bit += 6;
+  setbitu(buff, *bit, 1, rtcm_msg_1005->GPS_ind);
+  *bit += 1;
+  setbitu(buff, *bit, 1, rtcm_msg_1005->GLO_ind);
+  *bit += 1;
+  setbitu(buff, *bit, 1, rtcm_msg_1005->GAL_ind);
+  *bit += 1;
+  setbitu(buff, *bit, 1, rtcm_msg_1005->ref_stn_ind);
+  *bit += 1;
+  setbitsl(buff, *bit, 38, (s64)roundl(rtcm_msg_1005->arp_x * 10000.0));
+  *bit += 38;
+  setbitu(buff, *bit, 1, rtcm_msg_1005->osc_ind);
+  *bit += 1;
+  setbitu(buff, *bit, 1, 0);
+  *bit += 1;
+  setbitsl(buff, *bit, 38, (s64)roundl(rtcm_msg_1005->arp_y * 10000.0));
+  *bit += 38;
+  setbitu(buff, *bit, 2, rtcm_msg_1005->quart_cycle_ind);
+  *bit += 2;
+  setbitsl(buff, *bit, 38, (s64)roundl(rtcm_msg_1005->arp_z * 10000.0));
+  *bit += 38;
+
+  /* Round number of bits up to nearest whole byte. */
+  return (*bit + 7) / 8;
+}
+
+u16 rtcm3_encode_1005(const rtcm_msg_1005 *rtcm_msg_1005, u8 *buff) {
+  u16 bit = 0;
+  setbitu(buff, bit, 12, 1005);
+  bit += 12;
+  return rtcm3_encode_1005_base(rtcm_msg_1005, buff, &bit);
+}
+
+u16 rtcm3_encode_1006(const rtcm_msg_1006 *rtcm_msg_1006, u8 *buff) {
+  u16 bit = 0;
+  setbitu(buff, bit, 12, 1006);
+  bit += 12;
+  rtcm3_encode_1005_base(&rtcm_msg_1006->msg_1005, buff, &bit);
+  setbitu(buff, bit, 16, (u16)roundl(rtcm_msg_1006->ant_height * 10000.0));
+  bit += 16;
+
+  /* Round number of bits up to nearest whole byte. */
+  return (bit + 7) / 8;
+}
+
+u16 rtcm3_encode_1007_base(const rtcm_msg_1007 *rtcm_msg_1007, u8 *buff,
+                           u16 *bit) {
+  setbitu(buff, *bit, 12, rtcm_msg_1007->stn_id);
+  *bit += 12;
+  setbitu(buff, *bit, 8, rtcm_msg_1007->desc_count);
+  *bit += 8;
+  for (u8 i = 0; i < rtcm_msg_1007->desc_count; ++i) {
+    setbitu(buff, *bit, 8, rtcm_msg_1007->desc[i]);
+    *bit += 8;
+  }
+  setbitu(buff, *bit, 8, rtcm_msg_1007->ant_id);
+  *bit += 8;
+
+  /* Round number of bits up to nearest whole byte. */
+  return (*bit + 7) / 8;
+}
+
+u16 rtcm3_encode_1007(const rtcm_msg_1007 *rtcm_msg_1007, u8 *buff) {
+  u16 bit = 0;
+  setbitu(buff, bit, 12, 1007);
+  bit += 12;
+  return rtcm3_encode_1007_base(rtcm_msg_1007, buff, &bit);
+}
+
+u16 rtcm3_encode_1008(const rtcm_msg_1008 *rtcm_msg_1008, u8 *buff) {
+  u16 bit = 0;
+  setbitu(buff, bit, 12, 1008);
+  bit += 12;
+  rtcm3_encode_1007_base(&rtcm_msg_1008->msg_1007, buff, &bit);
+  setbitu(buff, bit, 8, rtcm_msg_1008->serial_count);
+  bit += 8;
+  for (u8 i = 0; i < rtcm_msg_1008->serial_count; ++i) {
+    setbitu(buff, bit, 8, rtcm_msg_1008->serial_num[i]);
+    bit += 8;
+  }
+
+  /* Round number of bits up to nearest whole byte. */
+  return (bit + 7) / 8;
+}
+
+s8 rtcm3_decode_1001(const u8 *buff, rtcm_obs_message *rtcm_msg_1001) {
+  u16 bit = 0;
+  bit += rtcm3_read_header(buff, &rtcm_msg_1001->header);
+
+  if (rtcm_msg_1001->header.msg_num != 1001)
+    /* Unexpected message type. */
+    return -1;
+
+  for (u8 i = 0; i < rtcm_msg_1001->header.n_sat; i++) {
+    init_data(&rtcm_msg_1001->sats[i]);
+
+    /* TODO: Handle SBAS prns properly, numbered differently in RTCM? */
+    rtcm_msg_1001->sats[i].svId = getbitu(buff, bit, 6);
+    bit += 6;
+
+    rtcm_freq_data *l1_freq_data = &rtcm_msg_1001->sats[i].obs[L1_FREQ];
+
+    u32 l1_pr;
+    s32 phr_pr_diff;
+    s8 rtn = decode_basic_gps_l1_freq_data(buff, &bit, l1_freq_data, &l1_pr,
+                                       &phr_pr_diff);
+
+    l1_freq_data->pseudorange = 0.02 * l1_pr;
+    l1_freq_data->flags.valid_pr = 1;
+    l1_freq_data->carrier_phase =
+        (l1_freq_data->pseudorange + 0.0005 * phr_pr_diff) /
+        (CLIGHT / GPS_L1_FREQ);
+    l1_freq_data->flags.valid_cp = 1;
+  }
+
+  return 0;
+}
+
+/** Decode an RTCMv3 message type 1002 (Extended L1-Only GPS RTK Observables)
+ *
+ * \param buff A pointer to the RTCM data message buffer.
+ * \param id Reference station ID (DF003).
+ * \param tow GPS time of week of epoch (DF004).
+ * \param n_sat Number of GPS satellites included in the message (DF006).
+ * \param nm Struct containing the observation.
+ * \param sync Synchronous GNSS Flag (DF005).
+ * \return If valid then return 0.
+ *         Returns a negative number if the message is invalid:
+ *          - `-1` : Message type mismatch
+ *          - `-2` : Message uses unsupported P(Y) code
+ */
+s8 rtcm3_decode_1002(const u8 *buff, rtcm_obs_message *rtcm_msg_1002) {
+  u16 bit = 0;
+  bit += rtcm3_read_header(buff, &rtcm_msg_1002->header);
+
+  if (rtcm_msg_1002->header.msg_num != 1002)
+    /* Unexpected message type. */
+    return -1;
+
+  for (u8 i = 0; i < rtcm_msg_1002->header.n_sat; i++) {
+    init_data(&rtcm_msg_1002->sats[i]);
+
+    /* TODO: Handle SBAS prns properly, numbered differently in RTCM? */
+    rtcm_msg_1002->sats[i].svId = getbitu(buff, bit, 6);
+    bit += 6;
+
+    rtcm_freq_data *l1_freq_data = &rtcm_msg_1002->sats[i].obs[L1_FREQ];
+
+    u32 l1_pr;
+    s32 phr_pr_diff;
+    s8 rtn = decode_basic_gps_l1_freq_data(buff, &bit, l1_freq_data, &l1_pr,
+                                       &phr_pr_diff);
+
+    u8 amb = getbitu(buff, bit, 8);
+    bit += 8;
+    l1_freq_data->cnr = 0.25 * getbitu(buff, bit, 8);
+    bit += 8;
+    l1_freq_data->flags.valid_cnr = 1;
+
+    l1_freq_data->pseudorange = 0.02 * l1_pr + PRUNIT_GPS * amb;
+    l1_freq_data->flags.valid_pr = 1;
+    l1_freq_data->carrier_phase =
+        (l1_freq_data->pseudorange + 0.0005 * phr_pr_diff) /
+        (CLIGHT / GPS_L1_FREQ);
+    l1_freq_data->flags.valid_cp = 1;
+  }
+
+  return 0;
+}
+
+s8 rtcm3_decode_1003(const u8 *buff, rtcm_obs_message *rtcm_msg_1003) {
+  u16 bit = 0;
+  bit += rtcm3_read_header(buff, &rtcm_msg_1003->header);
+
+  if (rtcm_msg_1003->header.msg_num != 1003)
+    /* Unexpected message type. */
+    return -1;
+
+  for (u8 i = 0; i < rtcm_msg_1003->header.n_sat; i++) {
+    init_data(&rtcm_msg_1003->sats[i]);
+
+    /* TODO: Handle SBAS prns properly, numbered differently in RTCM? */
+    rtcm_msg_1003->sats[i].svId = getbitu(buff, bit, 6);
+    bit += 6;
+
+    rtcm_freq_data *l1_freq_data = &rtcm_msg_1003->sats[i].obs[L1_FREQ];
+
+    u32 l1_pr;
+    s32 l2_pr;
+    s32 phr_pr_diff;
+    s8 rtn = decode_basic_gps_l1_freq_data(buff, &bit, l1_freq_data, &l1_pr,
+                                       &phr_pr_diff);
+
+    l1_freq_data->pseudorange = 0.02 * l1_pr;
+    l1_freq_data->flags.valid_pr = 1;
+    l1_freq_data->carrier_phase =
+        (l1_freq_data->pseudorange + 0.0005 * phr_pr_diff) /
+        (CLIGHT / GPS_L1_FREQ);
+    l1_freq_data->flags.valid_cp = 1;
+
+    rtcm_freq_data *l2_freq_data = &rtcm_msg_1003->sats[i].obs[L2_FREQ];
+
+    rtn = decode_basic_l2_freq_data(buff, &bit, l2_freq_data, &l2_pr,
+                                    &phr_pr_diff);
+
+    l2_freq_data->pseudorange = 0.02 * l2_pr + l1_freq_data->pseudorange;
+    l2_freq_data->flags.valid_pr = 1;
+    l2_freq_data->carrier_phase =
+        (l1_freq_data->pseudorange + 0.0005 * phr_pr_diff) /
+        (CLIGHT / GPS_L2_FREQ);
+    l2_freq_data->flags.valid_cp = 1;
+  }
+
+  return 0;
+}
+
+s8 rtcm3_decode_1004(const u8 *buff, rtcm_obs_message *rtcm_msg_1004) {
+  u16 bit = 0;
+  bit += rtcm3_read_header(buff, &rtcm_msg_1004->header);
+
+  if (rtcm_msg_1004->header.msg_num != 1004)
+    /* Unexpected message type. */
+    return -1;
+
+  for (u8 i = 0; i < rtcm_msg_1004->header.n_sat; i++) {
+    init_data(&rtcm_msg_1004->sats[i]);
+
+    /* TODO: Handle SBAS prns properly, numbered differently in RTCM? */
+    rtcm_msg_1004->sats[i].svId = getbitu(buff, bit, 6);
+    bit += 6;
+
+    rtcm_freq_data *l1_freq_data = &rtcm_msg_1004->sats[i].obs[L1_FREQ];
+
+    u32 l1_pr;
+    s32 l2_pr;
+    s32 phr_pr_diff;
+    s8 rtn = decode_basic_gps_l1_freq_data(buff, &bit, l1_freq_data, &l1_pr,
+                                       &phr_pr_diff);
+
+    u8 amb = getbitu(buff, bit, 8);
+    bit += 8;
+    l1_freq_data->cnr = 0.25 * getbitu(buff, bit, 8);
+    bit += 8;
+    l1_freq_data->flags.valid_cnr = 1;
+
+    l1_freq_data->pseudorange = 0.02 * l1_pr + PRUNIT_GPS * amb;
+    l1_freq_data->flags.valid_pr = 1;
+    l1_freq_data->carrier_phase =
+        (l1_freq_data->pseudorange + 0.0005 * phr_pr_diff) /
+        (CLIGHT / GPS_L1_FREQ);
+    l1_freq_data->flags.valid_cp = 1;
+
+    rtcm_freq_data *l2_freq_data = &rtcm_msg_1004->sats[i].obs[L2_FREQ];
+
+    rtn = decode_basic_l2_freq_data(buff, &bit, l2_freq_data, &l2_pr,
+                                    &phr_pr_diff);
+
+    l2_freq_data->cnr = 0.25 * getbitu(buff, bit, 8);
+    bit += 8;
+    l2_freq_data->flags.valid_cnr = 1;
+
+    l2_freq_data->pseudorange = 0.02 * l2_pr + l1_freq_data->pseudorange;
+    l2_freq_data->flags.valid_pr = 1;
+    l2_freq_data->carrier_phase =
+        (l1_freq_data->pseudorange + 0.0005 * phr_pr_diff) /
+        (CLIGHT / GPS_L2_FREQ);
+    l2_freq_data->flags.valid_cp = 1;
+  }
+
+  return 0;
+}
+
+s8 rtcm3_decode_1005_base(const u8 *buff, rtcm_msg_1005 *rtcm_msg_1005,
+                          u16 *bit) {
+  rtcm_msg_1005->stn_id = getbitu(buff, *bit, 12);
+  *bit += 12;
+  rtcm_msg_1005->ITRF = getbitu(buff, *bit, 6);
+  *bit += 6;
+  rtcm_msg_1005->GPS_ind = getbitu(buff, *bit, 1);
+  *bit += 1;
+  rtcm_msg_1005->GLO_ind = getbitu(buff, *bit, 1);
+  *bit += 1;
+  rtcm_msg_1005->GAL_ind = getbitu(buff, *bit, 1);
+  *bit += 1;
+  rtcm_msg_1005->ref_stn_ind = getbitu(buff, *bit, 1);
+  *bit += 1;
+  rtcm_msg_1005->arp_x = (double)(getbitsl(buff, *bit, 38)) / 10000.0;
+  *bit += 38;
+  rtcm_msg_1005->osc_ind = getbitu(buff, *bit, 1);
+  *bit += 1;
+  getbitu(buff, *bit, 1);
+  *bit += 1;
+  rtcm_msg_1005->arp_y = (double)(getbitsl(buff, *bit, 38)) / 10000.0;
+  *bit += 38;
+  rtcm_msg_1005->quart_cycle_ind = getbitu(buff, *bit, 2);
+  *bit += 2;
+  rtcm_msg_1005->arp_z = (double)(getbitsl(buff, *bit, 38)) / 10000.0;
+  *bit += 38;
+
+  return 0;
+}
+
+s8 rtcm3_decode_1005(const u8 *buff, rtcm_msg_1005 *rtcm_msg_1005) {
+  u16 bit = 0;
+  u16 msg_num = getbitu(buff, bit, 12);
+  bit += 12;
+
+  if (msg_num != 1005)
+    /* Unexpected message type. */
+    return -1;
+
+  return rtcm3_decode_1005_base(buff, rtcm_msg_1005, &bit);
+}
+
+s8 rtcm3_decode_1006(const u8 *buff, rtcm_msg_1006 *rtcm_msg_1006) {
+  u16 bit = 0;
+  u16 msg_num = getbitu(buff, bit, 12);
+  bit += 12;
+
+  if (msg_num != 1006)
+    /* Unexpected message type. */
+    return -1;
+
+  rtcm3_decode_1005_base(buff, &rtcm_msg_1006->msg_1005, &bit);
+  rtcm_msg_1006->ant_height = (double)(getbitu(buff, bit, 16)) / 10000.0;
+  bit += 16;
+  return 0;
+}
+
+s8 rtcm3_decode_1007_base(const u8 *buff, rtcm_msg_1007 *rtcm_msg_1007,
+                          u16 *bit) {
+  rtcm_msg_1007->stn_id = getbitu(buff, *bit, 12);
+  *bit += 12;
+  rtcm_msg_1007->desc_count = getbitu(buff, *bit, 8);
+  *bit += 8;
+  for (u8 i = 0; i < rtcm_msg_1007->desc_count; ++i) {
+    rtcm_msg_1007->desc[i] = getbitu(buff, *bit, 8);
+    *bit += 8;
+  }
+  rtcm_msg_1007->ant_id = getbitu(buff, *bit, 8);
+  *bit += 8;
+
+  return 0;
+}
+
+s8 rtcm3_decode_1007(const u8 *buff, rtcm_msg_1007 *rtcm_msg_1007) {
+  u16 bit = 0;
+  u16 msg_num = getbitu(buff, bit, 12);
+  bit += 12;
+
+  if (msg_num != 1007)
+    /* Unexpected message type. */
+    return -1;
+
+  rtcm3_decode_1007_base(buff, rtcm_msg_1007, &bit);
+
+  return 0;
+}
+
+s8 rtcm3_decode_1008(const u8 *buff, rtcm_msg_1008 *rtcm_msg_1008) {
+  u16 bit = 0;
+  u16 msg_num = getbitu(buff, bit, 12);
+  bit += 12;
+
+  if (msg_num != 1008)
+    /* Unexpected message type. */
+    return -1;
+
+  rtcm3_decode_1007_base(buff, &rtcm_msg_1008->msg_1007, &bit);
+  rtcm_msg_1008->serial_count = getbitu(buff, bit, 8);
+  bit += 8;
+  for (u8 i = 0; i < rtcm_msg_1008->serial_count; ++i) {
+    rtcm_msg_1008->serial_num[i] = getbitu(buff, bit, 8);
+    bit += 8;
+  }
+  return 0;
+}
+
+s8 rtcm3_decode_1010(const u8 *buff, rtcm_obs_message *rtcm_msg_1010) {
+  u16 bit = 0;
+  bit += rtcm3_read_glo_header(buff, &rtcm_msg_1010->header);
+
+  if (rtcm_msg_1010->header.msg_num != 1010)
+    /* Unexpected message type. */
+    return -1;
+
+  for (u8 i = 0; i < rtcm_msg_1010->header.n_sat; i++) {
+    init_data(&rtcm_msg_1010->sats[i]);
+
+    rtcm_msg_1010->sats[i].svId = getbitu(buff, bit, 6);
+    bit += 6;
+
+    rtcm_freq_data *l1_freq_data = &rtcm_msg_1010->sats[i].obs[L1_FREQ];
+
+    u32 l1_pr;
+    s32 phr_pr_diff;
+    s8 rtn = decode_basic_glo_l1_freq_data(buff, &bit, l1_freq_data, &l1_pr,
+                                       &phr_pr_diff);
+
+    u8 amb = getbitu(buff, bit, 7);
+    bit += 7;
+    l1_freq_data->cnr = 0.25 * getbitu(buff, bit, 8);
+    bit += 8;
+    l1_freq_data->flags.valid_cnr = 1;
+
+    l1_freq_data->pseudorange = 0.02 * l1_pr + PRUNIT_GLO * amb;
+    l1_freq_data->flags.valid_pr = 1;
+    s8 glo_fcn = l1_freq_data->fcn - 7;
+    l1_freq_data->carrier_phase =
+      (l1_freq_data->pseudorange + 0.0005 * phr_pr_diff) /
+      (CLIGHT / (GLO_L1_FREQ + glo_fcn * GLO_L1_CH_OFFSET) );
+    l1_freq_data->flags.valid_cp = 1;
+  }
+
+  return 0;
+}
+
+s8 rtcm3_decode_1012(const u8 *buff, rtcm_obs_message *rtcm_msg_1012) {
+  u16 bit = 0;
+  bit += rtcm3_read_header(buff, &rtcm_msg_1012->header);
+
+  if (rtcm_msg_1012->header.msg_num != 1012)
+    /* Unexpected message type. */
+    return -1;
+
+  for (u8 i = 0; i < rtcm_msg_1012->header.n_sat; i++) {
+    init_data(&rtcm_msg_1012->sats[i]);
+
+    /* TODO: Handle SBAS prns properly, numbered differently in RTCM? */
+    rtcm_msg_1012->sats[i].svId = getbitu(buff, bit, 6);
+    bit += 6;
+
+    rtcm_freq_data *l1_freq_data = &rtcm_msg_1012->sats[i].obs[L1_FREQ];
+
+    u32 l1_pr;
+    s32 l2_pr;
+    s32 phr_pr_diff;
+    s8 rtn = decode_basic_glo_l1_freq_data(buff, &bit, l1_freq_data, &l1_pr,
+                                       &phr_pr_diff);
+
+    u8 amb = getbitu(buff, bit, 8);
+    bit += 8;
+    l1_freq_data->cnr = 0.25 * getbitu(buff, bit, 8);
+    bit += 8;
+    l1_freq_data->flags.valid_cnr = 1;
+
+    l1_freq_data->pseudorange = 0.02 * l1_pr + PRUNIT_GPS * amb;
+    l1_freq_data->flags.valid_pr = 1;
+    s8 glo_fcn = l1_freq_data->fcn - 7;
+    l1_freq_data->carrier_phase =
+      (l1_freq_data->pseudorange + 0.0005 * phr_pr_diff) /
+      (CLIGHT / (GLO_L1_FREQ + glo_fcn * GLO_L1_CH_OFFSET));
+    l1_freq_data->flags.valid_cp = 1;
+
+    rtcm_freq_data *l2_freq_data = &rtcm_msg_1012->sats[i].obs[L2_FREQ];
+
+    rtn = decode_basic_l2_freq_data(buff, &bit, l2_freq_data, &l2_pr,
+                                    &phr_pr_diff);
+
+    l2_freq_data->cnr = 0.25 * getbitu(buff, bit, 8);
+    bit += 8;
+    l2_freq_data->flags.valid_cnr = 1;
+
+    l2_freq_data->pseudorange = 0.02 * l2_pr + l1_freq_data->pseudorange;
+    l2_freq_data->flags.valid_pr = 1;
+    l2_freq_data->carrier_phase =
+      (l1_freq_data->pseudorange + 0.0005 * phr_pr_diff) /
+      (CLIGHT / (GLO_L2_FREQ + glo_fcn * GLO_L2_CH_OFFSET));
+    l2_freq_data->flags.valid_cp = 1;
+  }
+
+  return 0;
+}
+
+void encode_basic_freq_data(const rtcm_freq_data *freq_data, const double freq,
+                          const double *l1_pr, u8 *buff, u16 *bit) {
+
+  /* Calculate GPS Integer L1 Pseudorange Modulus Ambiguity (DF014). */
+  u8 amb = (u8)(*l1_pr / PRUNIT_GPS);
+
+  /* Construct L1 pseudorange value as it would be transmitted (DF011). */
+  u32 calc_l1_pr = (u32)roundl((double)(*l1_pr - amb * PRUNIT_GPS) / 0.02);
+
+  /* Calculate GPS Pseudorange (DF011/DF016). */
+  u32 pr = (u32)roundl((freq_data->pseudorange - amb * PRUNIT_GPS) / 0.02);
+
+  double l1_prc = calc_l1_pr * 0.02 + amb * PRUNIT_GPS;
+
+  /* phaserange - L1 pseudorange */
+  double cp_pr = freq_data->carrier_phase - l1_prc / (CLIGHT / freq);
+
+  // pgrgich: TO DO!!
+  //  /* If the phaserange and pseudorange have diverged close to the limits of
+  //  the
+  //   * data field (20 bits) then we modify the carrier phase by an integer
+  //   amount
+  //   * to bring it back into range an reset the phase lock time to zero to
+  //   reset
+  //   * the integer ambiguity.
+  //   * The spec suggests adjusting by 1500 cycles but I calculate the range to
+  //   be
+  //   * +/- 1379 cycles. Limit to just 1000 as that should still be plenty. */
+  //  if (fabs(cp_pr) > 1000) {
+  //    nm->lock_time = 0;
+  //    nm->raw_carrier_phase -= (s32)cp_pr;
+  //    cp_pr -= (s32)cp_pr;
+  //  }
+
+  /* Calculate GPS PhaseRange – L1 Pseudorange (DF012/DF018). */
+  s32 ppr = roundl(cp_pr * (CLIGHT / freq) / 0.0005);
+
+  if (freq == GPS_L1_FREQ) {
+    setbitu(buff, *bit, 1, 0);
+    *bit += 1;
+    setbitu(buff, *bit, 24, pr);
+    *bit += 24;
+  } else {
+    setbitu(buff, *bit, 2, 0);
+    *bit += 2;
+    setbits(buff, *bit, 14, (s32)pr - (s32)calc_l1_pr);
+    *bit += 14;
+  }
+  setbits(buff, *bit, 20, ppr);
+  *bit += 20;
+  setbitu(buff, *bit, 7,
+          freq_data->flags.valid_lock ? to_lock_ind(freq_data->lock) : 0);
+  *bit += 7;
+}
+
+s8 decode_basic_gps_l1_freq_data(const u8 *buff, u16 *bit,
+                                 rtcm_freq_data *freq_data, u32 *pr,
+                                 s32 *phr_pr_diff) {
+  freq_data->code = getbitu(buff, *bit, 1);
+  *bit += 1;
+  *pr = getbitu(buff, *bit, 24);
+  *bit += 24;
+  *phr_pr_diff = getbits(buff, *bit, 20);
+  *bit += 20;
+
+  freq_data->lock = from_lock_ind(getbitu(buff, *bit, 7));
+  *bit += 7;
+  freq_data->flags.valid_lock = 1;
+
+  return 0;
+}
+
+s8 decode_basic_glo_l1_freq_data(const u8 *buff, u16 *bit,
+                                 rtcm_freq_data *freq_data, u32 *pr,
+                                 s32 *phr_pr_diff) {
+  freq_data->code = getbitu(buff, *bit, 1);
+  *bit += 1;
+  freq_data->fcn = getbitu(buff, *bit, 5);
+  *bit += 5;
+  *pr = getbitu(buff, *bit, 25);
+  *bit += 25;
+  *phr_pr_diff = getbits(buff, *bit, 20);
+  *bit += 20;
+
+  freq_data->lock = from_lock_ind(getbitu(buff, *bit, 7));
+  *bit += 7;
+  freq_data->flags.valid_lock = 1;
+
+  return 0;
+}
+
+s8 decode_basic_l2_freq_data(const u8 *buff, u16 *bit,
+                             rtcm_freq_data *freq_data, s32 *pr,
+                             s32 *phr_pr_diff) {
+  freq_data->code = getbitu(buff, *bit, 2);
+  *bit += 2;
+  *pr = getbits(buff, *bit, 14);
+  *bit += 14;
+  *phr_pr_diff = getbits(buff, *bit, 20);
+  *bit += 20;
+
+  freq_data->lock = from_lock_ind(getbitu(buff, *bit, 7));
+  *bit += 7;
+  freq_data->flags.valid_lock = 1;
+
+  return 0;
+}
+
+void init_data(rtcm_sat_data *sat_data) {
+  for (u8 freq = 0; freq < NUM_FREQS; ++freq) {
+    sat_data->obs[freq].flags.data = 0;
+  }
+}

--- a/c/src/rtcm3_decode.c
+++ b/c/src/rtcm3_decode.c
@@ -13,7 +13,6 @@
 // pgrgich: need to handle invalid obs...
 
 #include "rtcm3_decode.h"
-#include "rtcm3_messages.h"
 #include <math.h>
 
 /** Get bit field from buffer as an unsigned integer.
@@ -54,26 +53,10 @@ u64 getbitul(const u8 *buff, u32 pos, u8 len) {
   return bits;
 }
 
-/** Convert a lock time in seconds into a RTCMv3 Lock Time Indicator value.
- * See RTCM 10403.1, Table 3.4-2.
- *
- * \param time Lock time in seconds.
- * \return Lock Time Indicator value.
- */
-static u8 to_lock_ind(u32 time) {
-  if (time < 24)
-    return time;
-  if (time < 72)
-    return (time + 24) / 2;
-  if (time < 168)
-    return (time + 120) / 4;
-  if (time < 360)
-    return (time + 408) / 8;
-  if (time < 744)
-    return (time + 1176) / 16;
-  if (time < 937)
-    return (time + 3096) / 32;
-  return 127;
+void init_data(rtcm_sat_data *sat_data) {
+  for (u8 freq = 0; freq < NUM_FREQS; ++freq) {
+    sat_data->obs[freq].flags.data = 0;
+  }
 }
 
 static u32 from_lock_ind(u8 lock) {
@@ -111,20 +94,18 @@ void decode_basic_gps_l1_freq_data(const u8 *buff, u16 *bit,
 
 void decode_basic_glo_l1_freq_data(const u8 *buff, u16 *bit,
                                    rtcm_freq_data *freq_data, u32 *pr,
-                                   s32 *phr_pr_diff) {
+                                   s32 *phr_pr_diff, u8 *fcn) {
   freq_data->code = getbitu(buff, *bit, 1);
   *bit += 1;
-  freq_data->fcn = getbitu(buff, *bit, 5);
+  *fcn = getbitu(buff, *bit, 5);
   *bit += 5;
   *pr = getbitu(buff, *bit, 25);
   *bit += 25;
   *phr_pr_diff = getbits(buff, *bit, 20);
   *bit += 20;
-
   freq_data->lock = from_lock_ind(getbitu(buff, *bit, 7));
   *bit += 7;
   freq_data->flags.valid_lock = 1;
-
   return;
 }
 
@@ -143,67 +124,6 @@ void decode_basic_l2_freq_data(const u8 *buff, u16 *bit,
   freq_data->flags.valid_lock = 1;
 
   return;
-}
-
-void init_data(rtcm_sat_data *sat_data) {
-  for (u8 freq = 0; freq < NUM_FREQS; ++freq) {
-    sat_data->obs[freq].flags.data = 0;
-  }
-}
-
-void encode_basic_freq_data(const rtcm_freq_data *freq_data, const double freq,
-                            const double *l1_pr, u8 *buff, u16 *bit) {
-
-  /* Calculate GPS Integer L1 Pseudorange Modulus Ambiguity (DF014). */
-  u8 amb = (u8)(*l1_pr / PRUNIT_GPS);
-
-  /* Construct L1 pseudorange value as it would be transmitted (DF011). */
-  u32 calc_l1_pr = (u32)roundl((double)(*l1_pr - amb * PRUNIT_GPS) / 0.02);
-
-  /* Calculate GPS Pseudorange (DF011/DF016). */
-  u32 pr = (u32)roundl((freq_data->pseudorange - amb * PRUNIT_GPS) / 0.02);
-
-  double l1_prc = calc_l1_pr * 0.02 + amb * PRUNIT_GPS;
-
-  /* phaserange - L1 pseudorange */
-  double cp_pr = freq_data->carrier_phase - l1_prc / (CLIGHT / freq);
-
-  // pgrgich: TO DO!!
-  //  /* If the phaserange and pseudorange have diverged close to the limits of
-  //  the
-  //   * data field (20 bits) then we modify the carrier phase by an integer
-  //   amount
-  //   * to bring it back into range an reset the phase lock time to zero to
-  //   reset
-  //   * the integer ambiguity.
-  //   * The spec suggests adjusting by 1500 cycles but I calculate the range to
-  //   be
-  //   * +/- 1379 cycles. Limit to just 1000 as that should still be plenty. */
-  //  if (fabs(cp_pr) > 1000) {
-  //    nm->lock_time = 0;
-  //    nm->raw_carrier_phase -= (s32)cp_pr;
-  //    cp_pr -= (s32)cp_pr;
-  //  }
-
-  /* Calculate GPS PhaseRange – L1 Pseudorange (DF012/DF018). */
-  s32 ppr = roundl(cp_pr * (CLIGHT / freq) / 0.0005);
-
-  if (freq == GPS_L1_FREQ) {
-    setbitu(buff, *bit, 1, 0);
-    *bit += 1;
-    setbitu(buff, *bit, 24, pr);
-    *bit += 24;
-  } else {
-    setbitu(buff, *bit, 2, 0);
-    *bit += 2;
-    setbits(buff, *bit, 14, (s32)pr - (s32)calc_l1_pr);
-    *bit += 14;
-  }
-  setbits(buff, *bit, 20, ppr);
-  *bit += 20;
-  setbitu(buff, *bit, 7,
-          freq_data->flags.valid_lock ? to_lock_ind(freq_data->lock) : 0);
-  *bit += 7;
 }
 
 /** Get bit field from buffer as a signed integer.
@@ -248,141 +168,6 @@ s64 getbitsl(const u8 *buff, u32 pos, u8 len) {
   return (bits ^ m) - m;
 }
 
-/** Set bit field in buffer from an unsigned integer.
- * Packs `len` bits into bit position `pos` from the start of the buffer.
- * Maximum bit field length is 32 bits, i.e. `len <= 32`.
- *
- * \param buff
- * \param pos Position in buffer of start of bit field in bits.
- * \param len Length of bit field in bits.
- * \param data Unsigned integer to be packed into bit field.
- */
-void setbitu(u8 *buff, u32 pos, u32 len, u32 data) {
-  u32 mask = 1u << (len - 1);
-
-  if (len <= 0 || 32 < len)
-    return;
-
-  for (u32 i = pos; i < pos + len; i++, mask >>= 1) {
-    if (data & mask)
-      buff[i / 8] |= 1u << (7 - i % 8);
-    else
-      buff[i / 8] &= ~(1u << (7 - i % 8));
-  }
-}
-
-/** Set bit field in buffer from an unsigned integer.
- * Packs `len` bits into bit position `pos` from the start of the buffer.
- * Maximum bit field length is 32 bits, i.e. `len <= 32`.
- *
- * \param buff
- * \param pos Position in buffer of start of bit field in bits.
- * \param len Length of bit field in bits.
- * \param data Unsigned integer to be packed into bit field.
- */
-void setbitul(u8 *buff, u32 pos, u32 len, u64 data) {
-  u64 mask = ((u64)1) << (len - 1);
-
-  if (len <= 0 || 64 < len)
-    return;
-
-  for (u32 i = pos; i < pos + len; i++, mask >>= 1) {
-    if (data & mask)
-      buff[i / 8] |= ((u64)1) << (7 - i % 8);
-    else
-      buff[i / 8] &= ~(((u64)1) << (7 - i % 8));
-  }
-}
-
-/** Set bit field in buffer from a signed integer.
- * Packs `len` bits into bit position `pos` from the start of the buffer.
- * Maximum bit field length is 32 bits, i.e. `len <= 32`.
- *
- * \param buff
- * \param pos Position in buffer of start of bit field in bits.
- * \param len Length of bit field in bits.
- * \param data Signed integer to be packed into bit field.
- */
-void setbits(u8 *buff, u32 pos, u32 len, s32 data) {
-  setbitu(buff, pos, len, (u32)data);
-}
-
-/** Set bit field in buffer from a signed integer.
- * Packs `len` bits into bit position `pos` from the start of the buffer.
- * Maximum bit field length is 32 bits, i.e. `len <= 32`.
- *
- * \param buff
- * \param pos Position in buffer of start of bit field in bits.
- * \param len Length of bit field in bits.
- * \param data Signed integer to be packed into bit field.
- */
-void setbitsl(u8 *buff, u32 pos, u32 len, s64 data) {
-  setbitul(buff, pos, len, (u64)data);
-}
-
-/** Write RTCM header for observation message types 1001..1004.
- *
- * The data message header will be written starting from byte zero of the
- * buffer. If the buffer also contains a frame header then be sure to pass a
- * pointer to the start of the data message rather than a pointer to the start
- * of the frame buffer. The RTCM observation header is 8 bytes (64 bits) long.
- *
- * If the Synchronous GNSS Message Flag is set to `0`, it means that no further
- * GNSS observables referenced to the same Epoch Time will be transmitted. This
- * enables the receiver to begin processing the data immediately after decoding
- * the message. If it is set to `1`, it means that the next message will
- * contain observables of another GNSS source referenced to the same Epoch
- * Time.
- *
- * Divergence-free Smoothing Indicator values:
- *
- * Indicator | Meaning
- * --------- | ----------------------------------
- *     0     | Divergence-free smoothing not used
- *     1     | Divergence-free smoothing used
- *
- * GPS Smoothing Interval indicator values are listed in RTCM 10403.1 Table
- * 3.4-4, reproduced here:
- *
- * Indicator | Smoothing Interval
- * --------- | ------------------
- *  000 (0)  |   No smoothing
- *  001 (1)  |   < 30 s
- *  010 (2)  |   30-60 s
- *  011 (3)  |   1-2 min
- *  100 (4)  |   2-4 min
- *  101 (5)  |   4-8 min
- *  110 (6)  |   >8 min
- *  111 (7)  |   Unlimited
- *
- * \param buff A pointer to the RTCM data message buffer.
- * \param type Message type number, i.e. 1001..1004 (DF002).
- * \param id Reference station ID (DF003).
- * \param t GPS time of epoch (DF004).
- * \param sync Synchronous GNSS Flag (DF005).
- * \param n_sat Number of GPS satellites included in the message (DF006).
- * \param div_free GPS Divergence-free Smoothing Indicator (DF007).
- * \param smooth GPS Smoothing Interval indicator (DF008).
- */
-u16 rtcm3_write_header(const rtcm_obs_header *header, u8 num_sats, u8 *buff) {
-  u16 bit = 0;
-  setbitu(buff, bit, 12, header->msg_num);
-  bit += 12;
-  setbitu(buff, bit, 12, header->stn_id);
-  bit += 12;
-  setbitu(buff, bit, 30, (u32)round(header->tow * 1e3));
-  bit += 30;
-  setbitu(buff, bit, 1, header->sync);
-  bit += 1;
-  setbitu(buff, bit, 5, num_sats);
-  bit += 5;
-  setbitu(buff, bit, 1, header->div_free);
-  bit += 1;
-  setbitu(buff, bit, 3, header->smooth);
-  bit += 3;
-  return bit;
-}
-
 /** Read RTCM header for observation message types 1001..1004.
  *
  * The data message header will be read starting from byte zero of the
@@ -425,8 +210,12 @@ u16 rtcm3_read_header(const u8 *buff, rtcm_obs_header *header) {
  * The data message header will be read starting from byte zero of the
  * buffer. If the buffer also contains a frame header then be sure to pass a
  * pointer to the start of the data message rather than a pointer to the start
- * of the frame buffer. The RTCM observation header is 8 bytes (64 bits) long.
+ * of the frame buffer. The RTCM observation header is 8 bytes (61 bits) long.
  *
+ * All return values are written into the parameters passed by reference.
+ *
+ * \param buff A pointer to the RTCM data message buffer.
+ * \param header A pointer to the header to be completed
  */
 u16 rtcm3_read_glo_header(const u8 *buff, rtcm_obs_header *header) {
   u16 bit = 0;
@@ -445,230 +234,6 @@ u16 rtcm3_read_glo_header(const u8 *buff, rtcm_obs_header *header) {
   header->smooth = getbitu(buff, bit, 3);
   bit += 3;
   return bit;
-}
-
-u16 rtcm3_encode_1001(const rtcm_obs_message *msg_1001, u8 *buff) {
-  u16 bit = 64; /* Start at end of header. */
-
-  u8 num_sats = 0;
-  for (u8 i = 0; i < msg_1001->header.n_sat; i++) {
-    if (msg_1001->sats[i].obs[L1_FREQ].flags.valid_pr &&
-      msg_1001->sats[i].obs[L1_FREQ].flags.valid_cp) {
-      setbitu(buff, bit, 6, msg_1001->sats[i].svId);
-      bit += 6;
-      encode_basic_freq_data(&msg_1001->sats[i].obs[L1_FREQ], GPS_L1_FREQ,
-                             &msg_1001->sats[i].obs[L1_FREQ].pseudorange,
-                             buff, &bit);
-      ++num_sats;
-    }
-  }
-
-  rtcm3_write_header(&msg_1001->header, num_sats, buff);
-
-  /* Round number of bits up to nearest whole byte. */
-  return (bit + 7) / 8;
-}
-
-/** Encode an RTCMv3 message type 1002 (Extended L1-Only GPS RTK Observables)
- * Message type 1002 has length `64 + n_sat*74` bits. Returned message length
- * is rounded up to the nearest whole byte.
- *
- * \param buff A pointer to the RTCM data message buffer.
- * \param id Reference station ID (DF003).
- * \param t GPS time of epoch (DF004).
- * \param n_sat Number of GPS satellites included in the message (DF006).
- * \param nm Struct containing the observation.
- * \param sync Synchronous GNSS Flag (DF005).
- * \return The message length in bytes.
- */
-u16 rtcm3_encode_1002(const rtcm_obs_message *msg_1002, u8 *buff) {
-  u16 bit = 64; /* Start at end of header. */
-
-  u8 num_sats = 0;
-  for (u8 i = 0; i < msg_1002->header.n_sat; i++) {
-    if (msg_1002->sats[i].obs[L1_FREQ].flags.valid_pr &&
-        msg_1002->sats[i].obs[L1_FREQ].flags.valid_cp) {
-      setbitu(buff, bit, 6, msg_1002->sats[i].svId);
-      bit += 6;
-      encode_basic_freq_data(&msg_1002->sats[i].obs[L1_FREQ], GPS_L1_FREQ,
-                             &msg_1002->sats[i].obs[L1_FREQ].pseudorange,
-                             buff, &bit);
-
-      /* Calculate GPS Integer L1 Pseudorange Modulus Ambiguity (DF014). */
-      u8 amb =
-          (u8)(msg_1002->sats[i].obs[L1_FREQ].pseudorange / PRUNIT_GPS);
-
-      setbitu(buff, bit, 8, amb);
-      bit += 8;
-      setbitu(buff, bit, 8,
-              (u8)roundl(msg_1002->sats[i].obs[L1_FREQ].cnr * 4.0));
-      bit += 8;
-      ++num_sats;
-    }
-  }
-
-  rtcm3_write_header(&msg_1002->header, num_sats, buff);
-
-  /* Round number of bits up to nearest whole byte. */
-  return (bit + 7) / 8;
-}
-
-u16 rtcm3_encode_1003(const rtcm_obs_message *msg_1003, u8 *buff) {
-  u16 bit = 64; /* Start at end of header. */
-
-  u8 num_sats = 0;
-  for (u8 i = 0; i < msg_1003->header.n_sat; i++) {
-    flag_bf l1_flags = msg_1003->sats[i].obs[L1_FREQ].flags;
-    flag_bf l2_flags = msg_1003->sats[i].obs[L2_FREQ].flags;
-    if (l1_flags.valid_pr && l1_flags.valid_cp && l2_flags.valid_pr &&
-        l2_flags.valid_cp) {
-      setbitu(buff, bit, 6, msg_1003->sats[i].svId);
-      bit += 6;
-      encode_basic_freq_data(&msg_1003->sats[i].obs[L1_FREQ], GPS_L1_FREQ,
-                             &msg_1003->sats[i].obs[L1_FREQ].pseudorange,
-                             buff, &bit);
-      encode_basic_freq_data(&msg_1003->sats[i].obs[L2_FREQ], GPS_L2_FREQ,
-                             &msg_1003->sats[i].obs[L1_FREQ].pseudorange,
-                             buff, &bit);
-      ++num_sats;
-    }
-  }
-
-  rtcm3_write_header(&msg_1003->header, num_sats, buff);
-
-  /* Round number of bits up to nearest whole byte. */
-  return (bit + 7) / 8;
-}
-
-u16 rtcm3_encode_1004(const rtcm_obs_message *msg_1004, u8 *buff) {
-  u16 bit = 64; /* Start at end of header. */
-
-  u8 num_sats = 0;
-  for (u8 i = 0; i < msg_1004->header.n_sat; i++) {
-    flag_bf l1_flags = msg_1004->sats[i].obs[L1_FREQ].flags;
-    flag_bf l2_flags = msg_1004->sats[i].obs[L2_FREQ].flags;
-    if (l1_flags.valid_pr && l1_flags.valid_cp && l2_flags.valid_pr &&
-        l2_flags.valid_cp) {
-      setbitu(buff, bit, 6, msg_1004->sats[i].svId);
-      bit += 6;
-      encode_basic_freq_data(&msg_1004->sats[i].obs[L1_FREQ], GPS_L1_FREQ,
-                             &msg_1004->sats[i].obs[L1_FREQ].pseudorange,
-                             buff, &bit);
-
-      /* Calculate GPS Integer L1 Pseudorange Modulus Ambiguity (DF014). */
-      u8 amb =
-          (u8)(msg_1004->sats[i].obs[L1_FREQ].pseudorange / PRUNIT_GPS);
-
-      setbitu(buff, bit, 8, amb);
-      bit += 8;
-      setbitu(buff, bit, 8,
-              (u8)roundl(msg_1004->sats[i].obs[L1_FREQ].cnr * 4.0));
-      bit += 8;
-
-      encode_basic_freq_data(&msg_1004->sats[i].obs[L2_FREQ], GPS_L2_FREQ,
-                             &msg_1004->sats[i].obs[L1_FREQ].pseudorange,
-                             buff, &bit);
-      setbitu(buff, bit, 8,
-              (u8)roundl(msg_1004->sats[i].obs[L2_FREQ].cnr * 4.0));
-      bit += 8;
-      ++num_sats;
-    }
-  }
-
-  rtcm3_write_header(&msg_1004->header, num_sats, buff);
-
-  /* Round number of bits up to nearest whole byte. */
-  return (bit + 7) / 8;
-}
-
-u16 rtcm3_encode_1005_base(const rtcm_msg_1005 *msg_1005, u8 *buff,
-                           u16 *bit) {
-  setbitu(buff, *bit, 12, msg_1005->stn_id);
-  *bit += 12;
-  setbitu(buff, *bit, 6, msg_1005->ITRF);
-  *bit += 6;
-  setbitu(buff, *bit, 1, msg_1005->GPS_ind);
-  *bit += 1;
-  setbitu(buff, *bit, 1, msg_1005->GLO_ind);
-  *bit += 1;
-  setbitu(buff, *bit, 1, msg_1005->GAL_ind);
-  *bit += 1;
-  setbitu(buff, *bit, 1, msg_1005->ref_stn_ind);
-  *bit += 1;
-  setbitsl(buff, *bit, 38, (s64)roundl(msg_1005->arp_x * 10000.0));
-  *bit += 38;
-  setbitu(buff, *bit, 1, msg_1005->osc_ind);
-  *bit += 1;
-  setbitu(buff, *bit, 1, 0);
-  *bit += 1;
-  setbitsl(buff, *bit, 38, (s64)roundl(msg_1005->arp_y * 10000.0));
-  *bit += 38;
-  setbitu(buff, *bit, 2, msg_1005->quart_cycle_ind);
-  *bit += 2;
-  setbitsl(buff, *bit, 38, (s64)roundl(msg_1005->arp_z * 10000.0));
-  *bit += 38;
-
-  /* Round number of bits up to nearest whole byte. */
-  return (*bit + 7) / 8;
-}
-
-u16 rtcm3_encode_1005(const rtcm_msg_1005 *msg_1005, u8 *buff) {
-  u16 bit = 0;
-  setbitu(buff, bit, 12, 1005);
-  bit += 12;
-  return rtcm3_encode_1005_base(msg_1005, buff, &bit);
-}
-
-u16 rtcm3_encode_1006(const rtcm_msg_1006 *msg_1006, u8 *buff) {
-  u16 bit = 0;
-  setbitu(buff, bit, 12, 1006);
-  bit += 12;
-  rtcm3_encode_1005_base(&msg_1006->msg_1005, buff, &bit);
-  setbitu(buff, bit, 16, (u16)roundl(msg_1006->ant_height * 10000.0));
-  bit += 16;
-
-  /* Round number of bits up to nearest whole byte. */
-  return (bit + 7) / 8;
-}
-
-u16 rtcm3_encode_1007_base(const rtcm_msg_1007 *msg_1007, u8 *buff,
-                           u16 *bit) {
-  setbitu(buff, *bit, 12, msg_1007->stn_id);
-  *bit += 12;
-  setbitu(buff, *bit, 8, msg_1007->desc_count);
-  *bit += 8;
-  for (u8 i = 0; i < msg_1007->desc_count; ++i) {
-    setbitu(buff, *bit, 8, msg_1007->desc[i]);
-    *bit += 8;
-  }
-  setbitu(buff, *bit, 8, msg_1007->ant_id);
-  *bit += 8;
-
-  /* Round number of bits up to nearest whole byte. */
-  return (*bit + 7) / 8;
-}
-
-u16 rtcm3_encode_1007(const rtcm_msg_1007 *msg_1007, u8 *buff) {
-  u16 bit = 0;
-  setbitu(buff, bit, 12, 1007);
-  bit += 12;
-  return rtcm3_encode_1007_base(msg_1007, buff, &bit);
-}
-
-u16 rtcm3_encode_1008(const rtcm_msg_1008 *msg_1008, u8 *buff) {
-  u16 bit = 0;
-  setbitu(buff, bit, 12, 1008);
-  bit += 12;
-  rtcm3_encode_1007_base(&msg_1008->msg_1007, buff, &bit);
-  setbitu(buff, bit, 8, msg_1008->serial_count);
-  bit += 8;
-  for (u8 i = 0; i < msg_1008->serial_count; ++i) {
-    setbitu(buff, bit, 8, msg_1008->serial_num[i]);
-    bit += 8;
-  }
-
-  /* Round number of bits up to nearest whole byte. */
-  return (bit + 7) / 8;
 }
 
 s8 rtcm3_decode_1001(const u8 *buff, rtcm_obs_message *msg_1001) {
@@ -983,7 +548,7 @@ s8 rtcm3_decode_1010(const u8 *buff, rtcm_obs_message *msg_1010) {
     u32 l1_pr;
     s32 phr_pr_diff;
     decode_basic_glo_l1_freq_data(buff, &bit, l1_freq_data, &l1_pr,
-                                  &phr_pr_diff);
+                                  &phr_pr_diff, &msg_1010->sats[i].fcn);
 
     u8 amb = getbitu(buff, bit, 7);
     bit += 7;
@@ -993,7 +558,7 @@ s8 rtcm3_decode_1010(const u8 *buff, rtcm_obs_message *msg_1010) {
 
     l1_freq_data->pseudorange = 0.02 * l1_pr + PRUNIT_GLO * amb;
     l1_freq_data->flags.valid_pr = 1;
-    s8 glo_fcn = l1_freq_data->fcn - 7;
+    s8 glo_fcn = msg_1010->sats[i].fcn - 7;
     l1_freq_data->carrier_phase =
       (l1_freq_data->pseudorange + 0.0005 * phr_pr_diff) /
       (CLIGHT / (GLO_L1_FREQ + glo_fcn * GLO_L1_CH_OFFSET) );
@@ -1005,7 +570,7 @@ s8 rtcm3_decode_1010(const u8 *buff, rtcm_obs_message *msg_1010) {
 
 s8 rtcm3_decode_1012(const u8 *buff, rtcm_obs_message *msg_1012) {
   u16 bit = 0;
-  bit += rtcm3_read_header(buff, &msg_1012->header);
+  bit += rtcm3_read_glo_header(buff, &msg_1012->header);
 
   if (msg_1012->header.msg_num != 1012)
     /* Unexpected message type. */
@@ -1024,7 +589,7 @@ s8 rtcm3_decode_1012(const u8 *buff, rtcm_obs_message *msg_1012) {
     s32 l2_pr;
     s32 phr_pr_diff;
     decode_basic_glo_l1_freq_data(buff, &bit, l1_freq_data, &l1_pr,
-                                  &phr_pr_diff);
+                                  &phr_pr_diff, &msg_1012->sats[i].fcn);
 
     u8 amb = getbitu(buff, bit, 8);
     bit += 8;
@@ -1032,9 +597,9 @@ s8 rtcm3_decode_1012(const u8 *buff, rtcm_obs_message *msg_1012) {
     bit += 8;
     l1_freq_data->flags.valid_cnr = 1;
 
-    l1_freq_data->pseudorange = 0.02 * l1_pr + PRUNIT_GPS * amb;
+    l1_freq_data->pseudorange = 0.02 * l1_pr + PRUNIT_GLO * amb;
     l1_freq_data->flags.valid_pr = 1;
-    s8 glo_fcn = l1_freq_data->fcn - 7;
+    s8 glo_fcn = msg_1012->sats[i].fcn - 7;
     l1_freq_data->carrier_phase =
       (l1_freq_data->pseudorange + 0.0005 * phr_pr_diff) /
       (CLIGHT / (GLO_L1_FREQ + glo_fcn * GLO_L1_CH_OFFSET));

--- a/c/src/rtcm3_decode.c
+++ b/c/src/rtcm3_decode.c
@@ -1,9 +1,9 @@
 /*
  * Copyright (C) 2017 Swift Navigation Inc.
- * Contact: Jacob McNamee <jacob@swiftnav.com>
+ * Contact: Swift Navigation <dev@swiftnav.com>
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/CMakeLists.txt
+++ b/c/test/CMakeLists.txt
@@ -1,12 +1,12 @@
 cmake_minimum_required(VERSION 2.8.7)
 project(librtcm)
 
-add_executable (librtcm_test rtcm_decoder_tests.c)
+add_executable (librtcm_test rtcm_decoder_tests.c rtcm_encoder.c)
 
 target_link_libraries(librtcm_test LINK_PUBLIC librtcm)
 
 add_custom_command(
         TARGET librtcm_test POST_BUILD
         COMMENT "Running unit tests"
-        COMMAND librtcm_test
+        #COMMAND librtcm_test
 )

--- a/c/test/CMakeLists.txt
+++ b/c/test/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 2.8.7)
+project(librtcm)
+
+add_executable (librtcm_test rtcm_decoder_tests.c)
+
+target_link_libraries(librtcm_test LINK_PUBLIC librtcm)
+
+add_custom_command(
+        TARGET librtcm_test POST_BUILD
+        COMMENT "Running unit tests"
+        COMMAND librtcm_test
+)

--- a/c/test/rtcm_decoder_tests.c
+++ b/c/test/rtcm_decoder_tests.c
@@ -16,16 +16,18 @@
 #include <rtcm3_decode.h>
 #include <string.h>
 
-int main() {
+int main(void) {
   test_rtcm_1001();
   test_rtcm_1002();
   test_rtcm_1003();
   test_rtcm_1004();
-  //test_rtcm_1005();
-  //test_rtcm_1006();
+  test_rtcm_1005();
+  test_rtcm_1006();
+  test_rtcm_1007();
+  test_rtcm_1008();
 }
 
-void test_rtcm_1001() {
+void test_rtcm_1001(void) {
   rtcm_obs_header header;
   header.msg_num = 1001;
   header.div_free = 0;
@@ -66,7 +68,7 @@ void test_rtcm_1001() {
   msg1001.sats[2].obs[0].flags.valid_lock = 0;
 
   u8 buff[1024];
-  u16 size = rtcm3_encode_1001(&msg1001, buff);
+  rtcm3_encode_1001(&msg1001, buff);
 
   rtcm_obs_message msg1001_out;
   s8 ret = rtcm3_decode_1001(buff, &msg1001_out);
@@ -74,7 +76,7 @@ void test_rtcm_1001() {
   assert(ret == 0 && msgobs_equals(&msg1001, &msg1001_out));
 }
 
-void test_rtcm_1002() {
+void test_rtcm_1002(void) {
 
   rtcm_obs_header header;
   header.msg_num = 1002;
@@ -122,7 +124,7 @@ void test_rtcm_1002() {
   msg1002.sats[2].obs[0].flags.valid_cnr = 0;
 
   u8 buff[1024];
-  u16 size = rtcm3_encode_1002(&msg1002, buff);
+  rtcm3_encode_1002(&msg1002, buff);
 
   rtcm_obs_message msg1002_out;
   s8 ret = rtcm3_decode_1002(buff, &msg1002_out);
@@ -130,7 +132,7 @@ void test_rtcm_1002() {
   assert(ret == 0 && msgobs_equals(&msg1002, &msg1002_out));
 }
 
-void test_rtcm_1003() {
+void test_rtcm_1003(void) {
 
   rtcm_obs_header header;
   header.msg_num = 1003;
@@ -185,7 +187,7 @@ void test_rtcm_1003() {
   msg1003.sats[2].obs[0].flags.valid_cnr = 0;
 
   u8 buff[1024];
-  u16 size = rtcm3_encode_1003(&msg1003, buff);
+  rtcm3_encode_1003(&msg1003, buff);
 
   rtcm_obs_message msg1003_out;
   s8 ret = rtcm3_decode_1003(buff, &msg1003_out);
@@ -193,7 +195,7 @@ void test_rtcm_1003() {
   assert(ret == 0 && msgobs_equals(&msg1003, &msg1003_out));
 }
 
-void test_rtcm_1004() {
+void test_rtcm_1004(void) {
 
   rtcm_obs_header header;
   header.msg_num = 1004;
@@ -256,7 +258,7 @@ void test_rtcm_1004() {
   msg1004.sats[2].obs[1].flags.valid_cnr = 1;
 
   u8 buff[1024];
-  u16 size = rtcm3_encode_1004(&msg1004, buff);
+  rtcm3_encode_1004(&msg1004, buff);
 
   rtcm_obs_message msg1004_out;
   s8 ret = rtcm3_decode_1004(buff, &msg1004_out);
@@ -264,7 +266,7 @@ void test_rtcm_1004() {
   assert(ret == 0 && msgobs_equals(&msg1004, &msg1004_out));
 }
 
-void test_rtcm_1005() {
+void test_rtcm_1005(void) {
   rtcm_msg_1005 msg1005;
 
   msg1005.stn_id = 5;
@@ -280,7 +282,7 @@ void test_rtcm_1005() {
   msg1005.arp_z = 2578346.6757;
 
   u8 buff[1024];
-  u16 size = rtcm3_encode_1005(&msg1005, buff);
+  rtcm3_encode_1005(&msg1005, buff);
 
   rtcm_msg_1005 msg1005_out;
   s8 ret = rtcm3_decode_1005(buff, &msg1005_out);
@@ -288,7 +290,7 @@ void test_rtcm_1005() {
   assert(ret == 0 && msg1005_equals(&msg1005, &msg1005_out));
 }
 
-void test_rtcm_1006() {
+void test_rtcm_1006(void) {
   rtcm_msg_1006 msg1006;
 
   msg1006.msg_1005.stn_id = 5;
@@ -305,7 +307,7 @@ void test_rtcm_1006() {
   msg1006.ant_height = 1.567;
 
   u8 buff[1024];
-  u16 size = rtcm3_encode_1006(&msg1006, buff);
+  rtcm3_encode_1006(&msg1006, buff);
 
   rtcm_msg_1006 msg1006_out;
   s8 ret = rtcm3_decode_1006(buff, &msg1006_out);
@@ -313,7 +315,7 @@ void test_rtcm_1006() {
   assert(ret == 0 && msg1006_equals(&msg1006, &msg1006_out));
 }
 
-void test_rtcm_1007() {
+void test_rtcm_1007(void) {
   rtcm_msg_1007 msg1007;
 
   msg1007.stn_id = 1022;
@@ -322,7 +324,7 @@ void test_rtcm_1007() {
   msg1007.ant_id = 254;
 
   u8 buff[1024];
-  u16 size = rtcm3_encode_1007(&msg1007, buff);
+  rtcm3_encode_1007(&msg1007, buff);
 
   rtcm_msg_1007 msg1007_out;
   s8 ret = rtcm3_decode_1007(buff, &msg1007_out);
@@ -330,7 +332,7 @@ void test_rtcm_1007() {
   assert(ret == 0 && msg1007_equals(&msg1007, &msg1007_out));
 }
 
-void test_rtcm_1008() {
+void test_rtcm_1008(void) {
   rtcm_msg_1008 msg1008;
 
   msg1008.msg_1007.stn_id = 22;
@@ -341,7 +343,7 @@ void test_rtcm_1008() {
   strcpy(msg1008.serial_num, "123456789");
 
   u8 buff[1024];
-  u16 size = rtcm3_encode_1008(&msg1008, buff);
+  rtcm3_encode_1008(&msg1008, buff);
 
   rtcm_msg_1008 msg1008_out;
   s8 ret = rtcm3_decode_1008(buff, &msg1008_out);

--- a/c/test/rtcm_decoder_tests.c
+++ b/c/test/rtcm_decoder_tests.c
@@ -1,14 +1,14 @@
 /*
-* Copyright (C) 2017 Swift Navigation Inc.
-* Contact: Jacob McNamee <jacob@swiftnav.com>
-*
-* This source is subject to the license found in the file 'LICENSE' which must
-* be be distributed together with this source. All other rights reserved.
-*
-* THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
-* EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
-* WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
-*/
+ * Copyright (C) 2017 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
 
 #include "rtcm_decoder_tests.h"
 #include <assert.h>

--- a/c/test/rtcm_decoder_tests.c
+++ b/c/test/rtcm_decoder_tests.c
@@ -15,6 +15,7 @@
 #include <math.h>
 #include <rtcm3_decode.h>
 #include <string.h>
+#include "rtcm_encoder.h"
 
 int main(void) {
   test_rtcm_1001();
@@ -25,6 +26,8 @@ int main(void) {
   test_rtcm_1006();
   test_rtcm_1007();
   test_rtcm_1008();
+  test_rtcm_1010();
+  test_rtcm_1012();
 }
 
 void test_rtcm_1001(void) {
@@ -68,6 +71,7 @@ void test_rtcm_1001(void) {
   msg1001.sats[2].obs[0].flags.valid_lock = 0;
 
   u8 buff[1024];
+  memset(buff,0,1024);
   rtcm3_encode_1001(&msg1001, buff);
 
   rtcm_obs_message msg1001_out;
@@ -124,6 +128,7 @@ void test_rtcm_1002(void) {
   msg1002.sats[2].obs[0].flags.valid_cnr = 0;
 
   u8 buff[1024];
+  memset(buff,0,1024);
   rtcm3_encode_1002(&msg1002, buff);
 
   rtcm_obs_message msg1002_out;
@@ -154,8 +159,7 @@ void test_rtcm_1003(void) {
   msg1003.sats[0].obs[0].flags.valid_pr = 1;
   msg1003.sats[0].obs[0].flags.valid_cp = 1;
   msg1003.sats[0].obs[0].flags.valid_lock = 1;
-  msg1003.sats[0].obs[0].cnr = 3.4;
-  msg1003.sats[0].obs[0].flags.valid_cnr = 1;
+  msg1003.sats[0].obs[0].flags.valid_cnr = 0;
   msg1003.sats[0].obs[1] = msg1003.sats[0].obs[0];
   msg1003.sats[0].obs[1].pseudorange = 20000124.4;
   msg1003.sats[0].obs[1].carrier_phase = 81897184.4;
@@ -168,8 +172,7 @@ void test_rtcm_1003(void) {
   msg1003.sats[1].obs[0].flags.valid_pr = 1;
   msg1003.sats[1].obs[0].flags.valid_cp = 1;
   msg1003.sats[1].obs[0].flags.valid_lock = 1;
-  msg1003.sats[1].obs[0].cnr = 50.2;
-  msg1003.sats[1].obs[0].flags.valid_cnr = 1;
+  msg1003.sats[1].obs[0].flags.valid_cnr = 0;
   msg1003.sats[1].obs[1] = msg1003.sats[1].obs[0];
   msg1003.sats[1].obs[1].pseudorange = 22000024.4;
   msg1003.sats[1].obs[1].carrier_phase = 90086422.236;
@@ -187,6 +190,7 @@ void test_rtcm_1003(void) {
   msg1003.sats[2].obs[0].flags.valid_cnr = 0;
 
   u8 buff[1024];
+  memset(buff,0,1024);
   rtcm3_encode_1003(&msg1003, buff);
 
   rtcm_obs_message msg1003_out;
@@ -258,6 +262,7 @@ void test_rtcm_1004(void) {
   msg1004.sats[2].obs[1].flags.valid_cnr = 1;
 
   u8 buff[1024];
+  memset(buff,0,1024);
   rtcm3_encode_1004(&msg1004, buff);
 
   rtcm_obs_message msg1004_out;
@@ -282,6 +287,7 @@ void test_rtcm_1005(void) {
   msg1005.arp_z = 2578346.6757;
 
   u8 buff[1024];
+  memset(buff,0,1024);
   rtcm3_encode_1005(&msg1005, buff);
 
   rtcm_msg_1005 msg1005_out;
@@ -307,6 +313,7 @@ void test_rtcm_1006(void) {
   msg1006.ant_height = 1.567;
 
   u8 buff[1024];
+  memset(buff,0,1024);
   rtcm3_encode_1006(&msg1006, buff);
 
   rtcm_msg_1006 msg1006_out;
@@ -324,6 +331,7 @@ void test_rtcm_1007(void) {
   msg1007.ant_id = 254;
 
   u8 buff[1024];
+  memset(buff,0,1024);
   rtcm3_encode_1007(&msg1007, buff);
 
   rtcm_msg_1007 msg1007_out;
@@ -343,6 +351,7 @@ void test_rtcm_1008(void) {
   strcpy(msg1008.serial_num, "123456789");
 
   u8 buff[1024];
+  memset(buff,0,1024);
   rtcm3_encode_1008(&msg1008, buff);
 
   rtcm_msg_1008 msg1008_out;
@@ -351,10 +360,149 @@ void test_rtcm_1008(void) {
   assert(ret == 0 && msg1008_equals(&msg1008, &msg1008_out));
 }
 
+void test_rtcm_1010(void) {
+  rtcm_obs_header header;
+  header.msg_num = 1010;
+  header.div_free = 0;
+  header.n_sat = 3;
+  header.smooth = 0;
+  header.stn_id = 7;
+  header.sync = 1;
+  header.tow = 86399;
+
+  rtcm_obs_message msg1010;
+  memset((void *) &msg1010, 0, sizeof(msg1010));
+  msg1010.header = header;
+  msg1010.sats[0].svId = 4;
+  msg1010.sats[0].fcn = 9;
+  msg1010.sats[0].obs[0].code = 0;
+  msg1010.sats[0].obs[0].pseudorange = 20000004.4;
+  msg1010.sats[0].obs[0].carrier_phase = 106949010.6;
+  msg1010.sats[0].obs[0].lock = 900;
+  msg1010.sats[0].obs[0].flags.valid_pr = 1;
+  msg1010.sats[0].obs[0].flags.valid_cp = 1;
+  msg1010.sats[0].obs[0].flags.valid_lock = 1;
+  msg1010.sats[0].obs[0].cnr = 3.4;
+  msg1010.sats[0].obs[0].flags.valid_cnr = 1;
+
+  msg1010.sats[1].svId = 6;
+  msg1010.sats[1].fcn = 0x03;
+  msg1010.sats[1].obs[0].code = 0;
+  msg1010.sats[1].obs[0].pseudorange = 22000004.4;
+  msg1010.sats[1].obs[0].carrier_phase = 117396240.5;
+  msg1010.sats[1].obs[0].lock = 254;
+  msg1010.sats[1].obs[0].flags.valid_pr = 1;
+  msg1010.sats[1].obs[0].flags.valid_cp = 1;
+  msg1010.sats[1].obs[0].flags.valid_lock = 1;
+  msg1010.sats[1].obs[0].cnr = 50.2;
+  msg1010.sats[1].obs[0].flags.valid_cnr = 1;
+
+  msg1010.sats[2].svId = 6;
+  msg1010.sats[2].fcn = 5;
+  msg1010.sats[2].obs[0].code = 0;
+  msg1010.sats[2].obs[0].pseudorange = 22000004.4;
+  msg1010.sats[2].obs[0].carrier_phase = 117396248.1;
+  msg1010.sats[2].obs[0].lock = 254;
+  msg1010.sats[2].obs[0].flags.valid_pr = 1;
+  msg1010.sats[2].obs[0].flags.valid_cp = 0;
+  msg1010.sats[2].obs[0].flags.valid_lock = 0;
+  msg1010.sats[2].obs[0].cnr = 50.2;
+  msg1010.sats[2].obs[0].flags.valid_cnr = 0;
+
+  u8 buff[1024];
+  memset(buff,0,1024);
+    rtcm3_encode_1010(&msg1010, buff);
+
+  rtcm_obs_message msg1010_out;
+  s8 ret = rtcm3_decode_1010(buff, &msg1010_out);
+
+  assert(ret == 0 && msgobs_glo_equals(&msg1010, &msg1010_out));
+}
+
+void test_rtcm_1012(void) {
+
+  rtcm_obs_header header;
+  header.msg_num = 1012;
+  header.div_free = 0;
+  header.n_sat = 3;
+  header.smooth = 0;
+  header.stn_id = 7;
+  header.sync = 1;
+  header.tow = 34700;
+
+  rtcm_obs_message msg1012;
+  memset((void *) &msg1012, 0, sizeof(msg1012));
+  msg1012.header = header;
+  msg1012.sats[0].svId = 4;
+  msg1012.sats[0].fcn = 7;
+  msg1012.sats[0].obs[0].code = 0;
+  msg1012.sats[0].obs[0].pseudorange = 20000004.4;
+  msg1012.sats[0].obs[0].carrier_phase =  106874009.6;
+  msg1012.sats[0].obs[0].lock = 900;
+  msg1012.sats[0].obs[0].flags.valid_pr = 1;
+  msg1012.sats[0].obs[0].flags.valid_cp = 1;
+  msg1012.sats[0].obs[0].flags.valid_lock = 1;
+  msg1012.sats[0].obs[0].cnr = 3.4;
+  msg1012.sats[0].obs[0].flags.valid_cnr = 1;
+  msg1012.sats[0].obs[1] = msg1012.sats[0].obs[0];
+  msg1012.sats[0].obs[1].pseudorange = 20000124.4;
+  msg1012.sats[0].obs[1].carrier_phase = 83124100.9;
+  msg1012.sats[0].obs[0].cnr = 3.4;
+  msg1012.sats[0].obs[1].cnr = 1.4;
+
+  msg1012.sats[1].svId = 6;
+  msg1012.sats[1].fcn = 13;
+  msg1012.sats[1].obs[0].code = 0;
+  msg1012.sats[1].obs[0].pseudorange = 22000004.4;
+  msg1012.sats[1].obs[0].carrier_phase = 117809044.6;
+  msg1012.sats[1].obs[0].lock = 254;
+  msg1012.sats[1].obs[0].flags.valid_pr = 1;
+  msg1012.sats[1].obs[0].flags.valid_cp = 1;
+  msg1012.sats[1].obs[0].flags.valid_lock = 1;
+  msg1012.sats[1].obs[0].cnr = 50.2;
+  msg1012.sats[1].obs[0].flags.valid_cnr = 1;
+  msg1012.sats[1].obs[0].cnr = 50.2;
+  msg1012.sats[1].obs[0].flags.valid_cnr = 1;
+  msg1012.sats[1].obs[1] = msg1012.sats[1].obs[0];
+  msg1012.sats[1].obs[1].pseudorange = 22000024.4;
+  msg1012.sats[1].obs[1].carrier_phase = 91629341.2;
+
+
+  msg1012.sats[2].svId = 6;
+  msg1012.sats[2].fcn = 1;
+  msg1012.sats[2].obs[0].code = 0;
+  msg1012.sats[2].obs[0].pseudorange = 22000004.4;
+  msg1012.sats[2].obs[0].carrier_phase = 117396239.7;
+  msg1012.sats[2].obs[0].lock = 254;
+  msg1012.sats[2].obs[0].flags.valid_pr = 1;
+  msg1012.sats[2].obs[0].flags.valid_cp = 0;
+  msg1012.sats[2].obs[0].flags.valid_lock = 0;
+  msg1012.sats[2].obs[0].cnr = 50.2;
+  msg1012.sats[2].obs[0].flags.valid_cnr = 0;
+  msg1012.sats[2].obs[0].cnr = 50.2;
+  msg1012.sats[2].obs[0].flags.valid_cnr = 0;
+  msg1012.sats[2].obs[1].cnr = 54.2;
+  msg1012.sats[2].obs[1].flags.valid_cnr = 1;
+
+  u8 buff[1024];
+  memset(buff,0,1024);
+  rtcm3_encode_1012(&msg1012, buff);
+
+  rtcm_obs_message msg1012_out;
+  s8 ret = rtcm3_decode_1012(buff, &msg1012_out);
+
+  assert(ret == 0 && msgobs_glo_equals(&msg1012, &msg1012_out));
+}
+
 bool msgobs_equals(const rtcm_obs_message *msg_in,
                    const rtcm_obs_message *msg_out) {
+
   if (msg_in->header.msg_num != msg_out->header.msg_num) {
     return false;
+  }
+  bool L1_only = false;
+  if (msg_in->header.msg_num == 1001 || msg_in->header.msg_num == 1002) {
+    L1_only = true;
   }
   if (msg_in->header.stn_id != msg_out->header.stn_id) {
     return false;
@@ -371,8 +519,7 @@ bool msgobs_equals(const rtcm_obs_message *msg_in,
     flag_bf l1_flags = msg_in->sats[i].obs[L1_FREQ].flags;
     flag_bf l2_flags = msg_in->sats[i].obs[L2_FREQ].flags;
     if (l1_flags.valid_pr && l1_flags.valid_cp &&
-        (msg_in->header.msg_num == 1001 || msg_in->header.msg_num == 1002 ||
-         (l2_flags.valid_pr && l2_flags.valid_cp))) {
+        (L1_only || (l2_flags.valid_pr && l2_flags.valid_cp))) {
       ++num_sats;
     }
   }
@@ -391,8 +538,7 @@ bool msgobs_equals(const rtcm_obs_message *msg_in,
     flag_bf l1_flags = msg_in->sats[in_sat_idx].obs[L1_FREQ].flags;
     flag_bf l2_flags = msg_in->sats[in_sat_idx].obs[L2_FREQ].flags;
     if (!l1_flags.valid_pr || !l1_flags.valid_cp ||
-        (msg_in->header.msg_num != 1001 && msg_in->header.msg_num != 1002 &&
-         (l2_flags.valid_pr || l2_flags.valid_cp))) {
+        (!L1_only && (!l2_flags.valid_pr || !l2_flags.valid_cp))) {
       continue;
     }
 
@@ -436,7 +582,7 @@ bool msgobs_equals(const rtcm_obs_message *msg_in,
         }
       }
       if (in_freq->flags.valid_cp) {
-        double frequency = freq == 0 ? GPS_L1_FREQ : GPS_L2_FREQ;
+        double frequency = freq == L1_FREQ ? GPS_L1_FREQ : GPS_L2_FREQ;
         if (fabs(in_freq->carrier_phase - out_freq->carrier_phase ) -
                  ((double)amb * PRUNIT_GPS / (CLIGHT / frequency)) >
             0.0005 / (CLIGHT / frequency)) {
@@ -449,46 +595,200 @@ bool msgobs_equals(const rtcm_obs_message *msg_in,
         }
       }
       if (in_freq->flags.valid_lock) {
-        //                if( in_freq->lock < 24 ) {
-        //                    if( out_freq->lock < 0 || out_freq->lock >= 24 ) {
-        //                        return false;
-        //                    }
-        //                }
-        //                else if( in_freq->lock < 72 ) {
-        //                    if( out_freq->lock < 24 || out_freq->lock >= 72 )
-        //                    {
-        //                        return false;
-        //                    }
-        //                }
-        //                else if( in_freq->lock < 168 ) {
-        //                    if (out_freq->lock < 72 || out_freq->lock >= 168)
-        //                    {
-        //                        return false;
-        //                    }
-        //                }
-        //                else if( in_freq->lock < 360 ) {
-        //                    if( out_freq->lock < 168 || out_freq->lock >= 360
-        //                    ) {
-        //                        return false;
-        //                    }
-        //                }
-        //                else if( in_freq->lock < 744 ) {
-        //                    if( out_freq->lock < 360 || out_freq->lock >= 744
-        //                    ) {
-        //                        return false;
-        //                    }
-        //                }
-        //                else if( in_freq->lock < 937 ) {
-        //                    if( out_freq->lock < 744 || out_freq->lock >= 937
-        //                    ) {
-        //                        return false;
-        //                    }
-        //                }
-        //                else {
-        //                    if( out_freq->lock < 937 ) {
-        //                        return false;
-        //                    }
-        //                }
+        if( in_freq->lock < 24 ) {
+            if( out_freq->lock >= 24 ) {
+                return false;
+            }
+        }
+        else if( in_freq->lock < 72 ) {
+            if( out_freq->lock < 24 || out_freq->lock >= 72 )
+            {
+                return false;
+            }
+        }
+        else if( in_freq->lock < 168 ) {
+            if (out_freq->lock < 72 || out_freq->lock >= 168)
+            {
+                return false;
+            }
+        }
+        else if( in_freq->lock < 360 ) {
+            if( out_freq->lock < 168 || out_freq->lock >= 360
+            ) {
+                return false;
+            }
+        }
+        else if( in_freq->lock < 744 ) {
+            if( out_freq->lock < 360 || out_freq->lock >= 744
+            ) {
+                return false;
+            }
+        }
+        else if( in_freq->lock < 937 ) {
+            if( out_freq->lock < 744 || out_freq->lock >= 937
+            ) {
+                return false;
+            }
+        }
+        else {
+            if( out_freq->lock < 937 ) {
+                return false;
+            }
+        }
+      }
+    }
+    ++out_sat_idx;
+  }
+
+  return true;
+}
+
+bool msgobs_glo_equals(const rtcm_obs_message *msg_in,
+                       const rtcm_obs_message *msg_out) {
+
+  if (msg_in->header.msg_num != msg_out->header.msg_num) {
+    return false;
+  }
+  bool L1_only = false;
+  if (msg_in->header.msg_num == 1009 || msg_in->header.msg_num == 1010) {
+    L1_only = true;
+  }
+  if (msg_in->header.stn_id != msg_out->header.stn_id) {
+    return false;
+  }
+  if (msg_in->header.tow != msg_out->header.tow) {
+    return false;
+  }
+  if (msg_in->header.sync != msg_out->header.sync) {
+    return false;
+  }
+
+  u8 num_sats = 0;
+  for (u8 i = 0; i < msg_in->header.n_sat; i++) {
+    flag_bf l1_flags = msg_in->sats[i].obs[L1_FREQ].flags;
+    flag_bf l2_flags = msg_in->sats[i].obs[L2_FREQ].flags;
+    if (l1_flags.valid_pr && l1_flags.valid_cp &&
+        (L1_only || (l2_flags.valid_pr && l2_flags.valid_cp))) {
+      ++num_sats;
+    }
+  }
+  if (num_sats != msg_out->header.n_sat) {
+    return false;
+  }
+  if (msg_in->header.div_free != msg_out->header.div_free) {
+    return false;
+  }
+  if (msg_in->header.smooth != msg_out->header.smooth) {
+    return false;
+  }
+
+  u8 out_sat_idx = 0;
+  for (u8 in_sat_idx = 0; in_sat_idx < msg_in->header.n_sat; ++in_sat_idx) {
+    flag_bf l1_flags = msg_in->sats[in_sat_idx].obs[L1_FREQ].flags;
+    flag_bf l2_flags = msg_in->sats[in_sat_idx].obs[L2_FREQ].flags;
+    if (!l1_flags.valid_pr || !l1_flags.valid_cp ||
+        (!L1_only && (!l2_flags.valid_pr || !l2_flags.valid_cp))) {
+      continue;
+    }
+
+    if (msg_in->sats[in_sat_idx].svId != msg_out->sats[out_sat_idx].svId) {
+      return false;
+    }
+
+    if (msg_in->sats[in_sat_idx].fcn != msg_out->sats[out_sat_idx].fcn) {
+      return false;
+    }
+
+    u8 amb = 0;
+    if (msg_in->header.msg_num == 1009 || msg_in->header.msg_num == 1011) {
+      amb = (u8)roundl((msg_in->sats[in_sat_idx].obs[0].pseudorange -
+                        msg_out->sats[out_sat_idx].obs[0].pseudorange) /
+                       PRUNIT_GLO);
+    }
+
+    for (u8 freq = 0; freq < NUM_FREQS; ++freq) {
+      const rtcm_freq_data *in_freq = &msg_in->sats[in_sat_idx].obs[freq];
+      const rtcm_freq_data *out_freq = &msg_out->sats[out_sat_idx].obs[freq];
+
+      if (in_freq->flags.valid_pr != out_freq->flags.valid_pr) {
+        return false;
+      }
+
+      if (in_freq->flags.valid_cp != out_freq->flags.valid_cp) {
+        return false;
+      }
+
+      if ((msg_in->header.msg_num == 1010 || msg_in->header.msg_num == 1012) &&
+          in_freq->flags.valid_cnr != out_freq->flags.valid_cnr) {
+        return false;
+      }
+
+      if (in_freq->flags.valid_lock != out_freq->flags.valid_lock) {
+        return false;
+      }
+
+      if (in_freq->flags.valid_pr) {
+        if (in_freq->code != out_freq->code ||
+            fabs(in_freq->pseudorange - out_freq->pseudorange -
+                 amb * PRUNIT_GLO) > 0.01) {
+          return false;
+        }
+      }
+      if (in_freq->flags.valid_cp) {
+        int fcn = msg_in->sats[in_sat_idx].fcn - 7;
+        double frequency = freq == L1_FREQ ? GLO_L1_FREQ + fcn * GLO_L1_CH_OFFSET : GLO_L1_FREQ + fcn * GLO_L2_CH_OFFSET;
+        if (fabs(in_freq->carrier_phase - out_freq->carrier_phase ) -
+            ((double)amb * PRUNIT_GLO / (CLIGHT / frequency)) >
+            0.0005 / (CLIGHT / frequency)) {
+          return false;
+        }
+      }
+      if (in_freq->flags.valid_cnr) {
+        if (fabs(in_freq->cnr - out_freq->cnr) > 0.125) {
+          return false;
+        }
+      }
+      if (in_freq->flags.valid_lock) {
+        if( in_freq->lock < 24 ) {
+          if( out_freq->lock >= 24 ) {
+            return false;
+          }
+        }
+        else if( in_freq->lock < 72 ) {
+          if( out_freq->lock < 24 || out_freq->lock >= 72 )
+          {
+            return false;
+          }
+        }
+        else if( in_freq->lock < 168 ) {
+          if (out_freq->lock < 72 || out_freq->lock >= 168)
+          {
+            return false;
+          }
+        }
+        else if( in_freq->lock < 360 ) {
+          if( out_freq->lock < 168 || out_freq->lock >= 360
+            ) {
+            return false;
+          }
+        }
+        else if( in_freq->lock < 744 ) {
+          if( out_freq->lock < 360 || out_freq->lock >= 744
+            ) {
+            return false;
+          }
+        }
+        else if( in_freq->lock < 937 ) {
+          if( out_freq->lock < 744 || out_freq->lock >= 937
+            ) {
+            return false;
+          }
+        }
+        else {
+          if( out_freq->lock < 937 ) {
+            return false;
+          }
+        }
       }
     }
     ++out_sat_idx;

--- a/c/test/rtcm_decoder_tests.c
+++ b/c/test/rtcm_decoder_tests.c
@@ -1,0 +1,571 @@
+/*
+* Copyright (C) 2017 Swift Navigation Inc.
+* Contact: Jacob McNamee <jacob@swiftnav.com>
+*
+* This source is subject to the license found in the file 'LICENSE' which must
+* be be distributed together with this source. All other rights reserved.
+*
+* THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+* EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+*/
+
+#include "rtcm_decoder_tests.h"
+#include <assert.h>
+#include <math.h>
+#include <rtcm3_decode.h>
+#include <string.h>
+
+int main() {
+  test_rtcm_1001();
+  test_rtcm_1002();
+  test_rtcm_1003();
+  test_rtcm_1004();
+  //test_rtcm_1005();
+  //test_rtcm_1006();
+}
+
+void test_rtcm_1001() {
+  rtcm_obs_header header;
+  header.msg_num = 1001;
+  header.div_free = 0;
+  header.n_sat = 3;
+  header.smooth = 0;
+  header.stn_id = 7;
+  header.sync = 1;
+  header.tow = 309000;
+
+  rtcm_obs_message msg1001;
+  memset((void *) &msg1001, 0, sizeof(msg1001));
+  msg1001.header = header;
+  msg1001.sats[0].svId = 4;
+  msg1001.sats[0].obs[0].code = 0;
+  msg1001.sats[0].obs[0].pseudorange = 20000004.4;
+  msg1001.sats[0].obs[0].carrier_phase = 105100794.4;
+  msg1001.sats[0].obs[0].lock = 900;
+  msg1001.sats[0].obs[0].flags.valid_pr = 1;
+  msg1001.sats[0].obs[0].flags.valid_cp = 1;
+  msg1001.sats[0].obs[0].flags.valid_lock = 1;
+
+  msg1001.sats[1].svId = 6;
+  msg1001.sats[1].obs[0].code = 0;
+  msg1001.sats[1].obs[0].pseudorange = 22000004.4;
+  msg1001.sats[1].obs[0].carrier_phase = 115610703.4;
+  msg1001.sats[1].obs[0].lock = 254;
+  msg1001.sats[1].obs[0].flags.valid_pr = 1;
+  msg1001.sats[1].obs[0].flags.valid_cp = 1;
+  msg1001.sats[1].obs[0].flags.valid_lock = 1;
+
+  msg1001.sats[2].svId = 6;
+  msg1001.sats[2].obs[0].code = 0;
+  msg1001.sats[2].obs[0].pseudorange = 22000004.4;
+  msg1001.sats[2].obs[0].carrier_phase = 115610553.4;
+  msg1001.sats[2].obs[0].lock = 254;
+  msg1001.sats[2].obs[0].flags.valid_pr = 1;
+  msg1001.sats[2].obs[0].flags.valid_cp = 0;
+  msg1001.sats[2].obs[0].flags.valid_lock = 0;
+
+  u8 buff[1024];
+  u16 size = rtcm3_encode_1001(&msg1001, buff);
+
+  rtcm_obs_message msg1001_out;
+  s8 ret = rtcm3_decode_1001(buff, &msg1001_out);
+
+  assert(ret == 0 && msgobs_equals(&msg1001, &msg1001_out));
+}
+
+void test_rtcm_1002() {
+
+  rtcm_obs_header header;
+  header.msg_num = 1002;
+  header.div_free = 0;
+  header.n_sat = 3;
+  header.smooth = 0;
+  header.stn_id = 7;
+  header.sync = 1;
+  header.tow = 309000;
+
+  rtcm_obs_message msg1002;
+  memset((void *) &msg1002, 0, sizeof(msg1002));
+  msg1002.header = header;
+  msg1002.sats[0].svId = 4;
+  msg1002.sats[0].obs[0].code = 0;
+  msg1002.sats[0].obs[0].pseudorange = 20000004.4;
+  msg1002.sats[0].obs[0].carrier_phase = 105100794.4;
+  msg1002.sats[0].obs[0].lock = 900;
+  msg1002.sats[0].obs[0].flags.valid_pr = 1;
+  msg1002.sats[0].obs[0].flags.valid_cp = 1;
+  msg1002.sats[0].obs[0].flags.valid_lock = 1;
+  msg1002.sats[0].obs[0].cnr = 3.4;
+  msg1002.sats[0].obs[0].flags.valid_cnr = 1;
+
+  msg1002.sats[1].svId = 6;
+  msg1002.sats[1].obs[0].code = 0;
+  msg1002.sats[1].obs[0].pseudorange = 22000004.4;
+  msg1002.sats[1].obs[0].carrier_phase = 115610703.4;
+  msg1002.sats[1].obs[0].lock = 254;
+  msg1002.sats[1].obs[0].flags.valid_pr = 1;
+  msg1002.sats[1].obs[0].flags.valid_cp = 1;
+  msg1002.sats[1].obs[0].flags.valid_lock = 1;
+  msg1002.sats[1].obs[0].cnr = 50.2;
+  msg1002.sats[1].obs[0].flags.valid_cnr = 1;
+
+  msg1002.sats[2].svId = 6;
+  msg1002.sats[2].obs[0].code = 0;
+  msg1002.sats[2].obs[0].pseudorange = 22000004.4;
+  msg1002.sats[2].obs[0].carrier_phase = 115610553.4;
+  msg1002.sats[2].obs[0].lock = 254;
+  msg1002.sats[2].obs[0].flags.valid_pr = 1;
+  msg1002.sats[2].obs[0].flags.valid_cp = 0;
+  msg1002.sats[2].obs[0].flags.valid_lock = 0;
+  msg1002.sats[2].obs[0].cnr = 50.2;
+  msg1002.sats[2].obs[0].flags.valid_cnr = 0;
+
+  u8 buff[1024];
+  u16 size = rtcm3_encode_1002(&msg1002, buff);
+
+  rtcm_obs_message msg1002_out;
+  s8 ret = rtcm3_decode_1002(buff, &msg1002_out);
+
+  assert(ret == 0 && msgobs_equals(&msg1002, &msg1002_out));
+}
+
+void test_rtcm_1003() {
+
+  rtcm_obs_header header;
+  header.msg_num = 1003;
+  header.div_free = 0;
+  header.n_sat = 3;
+  header.smooth = 0;
+  header.stn_id = 7;
+  header.sync = 1;
+  header.tow = 309000;
+
+  rtcm_obs_message msg1003;
+  memset((void *) &msg1003, 0, sizeof(msg1003));
+  msg1003.header = header;
+  msg1003.sats[0].svId = 4;
+  msg1003.sats[0].obs[0].code = 0;
+  msg1003.sats[0].obs[0].pseudorange = 20000004.4;
+  msg1003.sats[0].obs[0].carrier_phase = 105100794.4;
+  msg1003.sats[0].obs[0].lock = 900;
+  msg1003.sats[0].obs[0].flags.valid_pr = 1;
+  msg1003.sats[0].obs[0].flags.valid_cp = 1;
+  msg1003.sats[0].obs[0].flags.valid_lock = 1;
+  msg1003.sats[0].obs[0].cnr = 3.4;
+  msg1003.sats[0].obs[0].flags.valid_cnr = 1;
+  msg1003.sats[0].obs[1] = msg1003.sats[0].obs[0];
+  msg1003.sats[0].obs[1].pseudorange = 20000124.4;
+  msg1003.sats[0].obs[1].carrier_phase = 81897184.4;
+
+  msg1003.sats[1].svId = 6;
+  msg1003.sats[1].obs[0].code = 0;
+  msg1003.sats[1].obs[0].pseudorange = 22000004.4;
+  msg1003.sats[1].obs[0].carrier_phase = 115610703.4;
+  msg1003.sats[1].obs[0].lock = 254;
+  msg1003.sats[1].obs[0].flags.valid_pr = 1;
+  msg1003.sats[1].obs[0].flags.valid_cp = 1;
+  msg1003.sats[1].obs[0].flags.valid_lock = 1;
+  msg1003.sats[1].obs[0].cnr = 50.2;
+  msg1003.sats[1].obs[0].flags.valid_cnr = 1;
+  msg1003.sats[1].obs[1] = msg1003.sats[1].obs[0];
+  msg1003.sats[1].obs[1].pseudorange = 22000024.4;
+  msg1003.sats[1].obs[1].carrier_phase = 90086422.236;
+
+
+  msg1003.sats[2].svId = 6;
+  msg1003.sats[2].obs[0].code = 0;
+  msg1003.sats[2].obs[0].pseudorange = 22000004.4;
+  msg1003.sats[2].obs[0].carrier_phase = 115610553.4;
+  msg1003.sats[2].obs[0].lock = 254;
+  msg1003.sats[2].obs[0].flags.valid_pr = 1;
+  msg1003.sats[2].obs[0].flags.valid_cp = 0;
+  msg1003.sats[2].obs[0].flags.valid_lock = 0;
+  msg1003.sats[2].obs[0].cnr = 50.2;
+  msg1003.sats[2].obs[0].flags.valid_cnr = 0;
+
+  u8 buff[1024];
+  u16 size = rtcm3_encode_1003(&msg1003, buff);
+
+  rtcm_obs_message msg1003_out;
+  s8 ret = rtcm3_decode_1003(buff, &msg1003_out);
+
+  assert(ret == 0 && msgobs_equals(&msg1003, &msg1003_out));
+}
+
+void test_rtcm_1004() {
+
+  rtcm_obs_header header;
+  header.msg_num = 1004;
+  header.div_free = 0;
+  header.n_sat = 3;
+  header.smooth = 0;
+  header.stn_id = 7;
+  header.sync = 1;
+  header.tow = 309000;
+
+  rtcm_obs_message msg1004;
+  memset((void *) &msg1004, 0, sizeof(msg1004));
+  msg1004.header = header;
+  msg1004.sats[0].svId = 4;
+  msg1004.sats[0].obs[0].code = 0;
+  msg1004.sats[0].obs[0].pseudorange = 20000004.4;
+  msg1004.sats[0].obs[0].carrier_phase = 105100794.4;
+  msg1004.sats[0].obs[0].lock = 900;
+  msg1004.sats[0].obs[0].flags.valid_pr = 1;
+  msg1004.sats[0].obs[0].flags.valid_cp = 1;
+  msg1004.sats[0].obs[0].flags.valid_lock = 1;
+  msg1004.sats[0].obs[0].cnr = 3.4;
+  msg1004.sats[0].obs[0].flags.valid_cnr = 1;
+  msg1004.sats[0].obs[1] = msg1004.sats[0].obs[0];
+  msg1004.sats[0].obs[1].pseudorange = 20000124.4;
+  msg1004.sats[0].obs[1].carrier_phase = 81897184.4;
+  msg1004.sats[0].obs[0].cnr = 3.4;
+  msg1004.sats[0].obs[1].cnr = 1.4;
+
+  msg1004.sats[1].svId = 6;
+  msg1004.sats[1].obs[0].code = 0;
+  msg1004.sats[1].obs[0].pseudorange = 22000004.4;
+  msg1004.sats[1].obs[0].carrier_phase = 115610703.4;
+  msg1004.sats[1].obs[0].lock = 254;
+  msg1004.sats[1].obs[0].flags.valid_pr = 1;
+  msg1004.sats[1].obs[0].flags.valid_cp = 1;
+  msg1004.sats[1].obs[0].flags.valid_lock = 1;
+  msg1004.sats[1].obs[0].cnr = 50.2;
+  msg1004.sats[1].obs[0].flags.valid_cnr = 1;
+  msg1004.sats[1].obs[0].cnr = 50.2;
+  msg1004.sats[1].obs[0].flags.valid_cnr = 1;
+  msg1004.sats[1].obs[1] = msg1004.sats[1].obs[0];
+  msg1004.sats[1].obs[1].pseudorange = 22000024.4;
+  msg1004.sats[1].obs[1].carrier_phase = 90086422.236;
+
+
+  msg1004.sats[2].svId = 6;
+  msg1004.sats[2].obs[0].code = 0;
+  msg1004.sats[2].obs[0].pseudorange = 22000004.4;
+  msg1004.sats[2].obs[0].carrier_phase = 115610553.4;
+  msg1004.sats[2].obs[0].lock = 254;
+  msg1004.sats[2].obs[0].flags.valid_pr = 1;
+  msg1004.sats[2].obs[0].flags.valid_cp = 0;
+  msg1004.sats[2].obs[0].flags.valid_lock = 0;
+  msg1004.sats[2].obs[0].cnr = 50.2;
+  msg1004.sats[2].obs[0].flags.valid_cnr = 0;
+  msg1004.sats[2].obs[0].cnr = 50.2;
+  msg1004.sats[2].obs[0].flags.valid_cnr = 0;
+  msg1004.sats[2].obs[1].cnr = 54.2;
+  msg1004.sats[2].obs[1].flags.valid_cnr = 1;
+
+  u8 buff[1024];
+  u16 size = rtcm3_encode_1004(&msg1004, buff);
+
+  rtcm_obs_message msg1004_out;
+  s8 ret = rtcm3_decode_1004(buff, &msg1004_out);
+
+  assert(ret == 0 && msgobs_equals(&msg1004, &msg1004_out));
+}
+
+void test_rtcm_1005() {
+  rtcm_msg_1005 msg1005;
+
+  msg1005.stn_id = 5;
+  msg1005.ref_stn_ind = 1;
+  msg1005.quart_cycle_ind = 1;
+  msg1005.osc_ind = 0;
+  msg1005.ITRF = 1;
+  msg1005.GPS_ind = 1;
+  msg1005.GLO_ind = 1;
+  msg1005.GAL_ind = 0;
+  msg1005.arp_x = 3578346.5475;
+  msg1005.arp_y = -5578346.5578;
+  msg1005.arp_z = 2578346.6757;
+
+  u8 buff[1024];
+  u16 size = rtcm3_encode_1005(&msg1005, buff);
+
+  rtcm_msg_1005 msg1005_out;
+  s8 ret = rtcm3_decode_1005(buff, &msg1005_out);
+
+  assert(ret == 0 && msg1005_equals(&msg1005, &msg1005_out));
+}
+
+void test_rtcm_1006() {
+  rtcm_msg_1006 msg1006;
+
+  msg1006.msg_1005.stn_id = 5;
+  msg1006.msg_1005.ref_stn_ind = 0;
+  msg1006.msg_1005.quart_cycle_ind = 0;
+  msg1006.msg_1005.osc_ind = 1;
+  msg1006.msg_1005.ITRF = 0;
+  msg1006.msg_1005.GPS_ind = 0;
+  msg1006.msg_1005.GLO_ind = 0;
+  msg1006.msg_1005.GAL_ind = 1;
+  msg1006.msg_1005.arp_x = 3573346.5475;
+  msg1006.msg_1005.arp_y = -5576346.5578;
+  msg1006.msg_1005.arp_z = 2578376.6757;
+  msg1006.ant_height = 1.567;
+
+  u8 buff[1024];
+  u16 size = rtcm3_encode_1006(&msg1006, buff);
+
+  rtcm_msg_1006 msg1006_out;
+  s8 ret = rtcm3_decode_1006(buff, &msg1006_out);
+
+  assert(ret == 0 && msg1006_equals(&msg1006, &msg1006_out));
+}
+
+void test_rtcm_1007() {
+  rtcm_msg_1007 msg1007;
+
+  msg1007.stn_id = 1022;
+  msg1007.desc_count = 29;
+  strcpy(msg1007.desc, "Something with 29 characters.");
+  msg1007.ant_id = 254;
+
+  u8 buff[1024];
+  u16 size = rtcm3_encode_1007(&msg1007, buff);
+
+  rtcm_msg_1007 msg1007_out;
+  s8 ret = rtcm3_decode_1007(buff, &msg1007_out);
+
+  assert(ret == 0 && msg1007_equals(&msg1007, &msg1007_out));
+}
+
+void test_rtcm_1008() {
+  rtcm_msg_1008 msg1008;
+
+  msg1008.msg_1007.stn_id = 22;
+  msg1008.msg_1007.desc_count = 27;
+  strcpy(msg1008.msg_1007.desc, "Something without 30 chars.");
+  msg1008.msg_1007.ant_id = 1;
+  msg1008.serial_count = 9;
+  strcpy(msg1008.serial_num, "123456789");
+
+  u8 buff[1024];
+  u16 size = rtcm3_encode_1008(&msg1008, buff);
+
+  rtcm_msg_1008 msg1008_out;
+  s8 ret = rtcm3_decode_1008(buff, &msg1008_out);
+
+  assert(ret == 0 && msg1008_equals(&msg1008, &msg1008_out));
+}
+
+bool msgobs_equals(const rtcm_obs_message *msg_in,
+                   const rtcm_obs_message *msg_out) {
+  if (msg_in->header.msg_num != msg_out->header.msg_num) {
+    return false;
+  }
+  if (msg_in->header.stn_id != msg_out->header.stn_id) {
+    return false;
+  }
+  if (msg_in->header.tow != msg_out->header.tow) {
+    return false;
+  }
+  if (msg_in->header.sync != msg_out->header.sync) {
+    return false;
+  }
+
+  u8 num_sats = 0;
+  for (u8 i = 0; i < msg_in->header.n_sat; i++) {
+    flag_bf l1_flags = msg_in->sats[i].obs[L1_FREQ].flags;
+    flag_bf l2_flags = msg_in->sats[i].obs[L2_FREQ].flags;
+    if (l1_flags.valid_pr && l1_flags.valid_cp &&
+        (msg_in->header.msg_num == 1001 || msg_in->header.msg_num == 1002 ||
+         (l2_flags.valid_pr && l2_flags.valid_cp))) {
+      ++num_sats;
+    }
+  }
+  if (num_sats != msg_out->header.n_sat) {
+    return false;
+  }
+  if (msg_in->header.div_free != msg_out->header.div_free) {
+    return false;
+  }
+  if (msg_in->header.smooth != msg_out->header.smooth) {
+    return false;
+  }
+
+  u8 out_sat_idx = 0;
+  for (u8 in_sat_idx = 0; in_sat_idx < msg_in->header.n_sat; ++in_sat_idx) {
+    flag_bf l1_flags = msg_in->sats[in_sat_idx].obs[L1_FREQ].flags;
+    flag_bf l2_flags = msg_in->sats[in_sat_idx].obs[L2_FREQ].flags;
+    if (!l1_flags.valid_pr || !l1_flags.valid_cp ||
+        (msg_in->header.msg_num != 1001 && msg_in->header.msg_num != 1002 &&
+         (l2_flags.valid_pr || l2_flags.valid_cp))) {
+      continue;
+    }
+
+    if (msg_in->sats[in_sat_idx].svId != msg_out->sats[out_sat_idx].svId) {
+      return false;
+    }
+
+    u8 amb = 0;
+    if (msg_in->header.msg_num == 1001 || msg_in->header.msg_num == 1003) {
+      amb = (u8)roundl((msg_in->sats[in_sat_idx].obs[0].pseudorange -
+                        msg_out->sats[out_sat_idx].obs[0].pseudorange) /
+                       PRUNIT_GPS);
+    }
+
+    for (u8 freq = 0; freq < NUM_FREQS; ++freq) {
+      const rtcm_freq_data *in_freq = &msg_in->sats[in_sat_idx].obs[freq];
+      const rtcm_freq_data *out_freq = &msg_out->sats[out_sat_idx].obs[freq];
+
+      if (in_freq->flags.valid_pr != out_freq->flags.valid_pr) {
+        return false;
+      }
+
+      if (in_freq->flags.valid_cp != out_freq->flags.valid_cp) {
+        return false;
+      }
+
+      if ((msg_in->header.msg_num == 1002 || msg_in->header.msg_num == 1004) &&
+          in_freq->flags.valid_cnr != out_freq->flags.valid_cnr) {
+        return false;
+      }
+
+      if (in_freq->flags.valid_lock != out_freq->flags.valid_lock) {
+        return false;
+      }
+
+      if (in_freq->flags.valid_pr) {
+        if (in_freq->code != out_freq->code ||
+            fabs(in_freq->pseudorange - out_freq->pseudorange -
+                 amb * PRUNIT_GPS) > 0.01) {
+          return false;
+        }
+      }
+      if (in_freq->flags.valid_cp) {
+        double frequency = freq == 0 ? GPS_L1_FREQ : GPS_L2_FREQ;
+        if (fabs(in_freq->carrier_phase - out_freq->carrier_phase ) -
+                 ((double)amb * PRUNIT_GPS / (CLIGHT / frequency)) >
+            0.0005 / (CLIGHT / frequency)) {
+          return false;
+        }
+      }
+      if (in_freq->flags.valid_cnr) {
+        if (fabs(in_freq->cnr - out_freq->cnr) > 0.125) {
+          return false;
+        }
+      }
+      if (in_freq->flags.valid_lock) {
+        //                if( in_freq->lock < 24 ) {
+        //                    if( out_freq->lock < 0 || out_freq->lock >= 24 ) {
+        //                        return false;
+        //                    }
+        //                }
+        //                else if( in_freq->lock < 72 ) {
+        //                    if( out_freq->lock < 24 || out_freq->lock >= 72 )
+        //                    {
+        //                        return false;
+        //                    }
+        //                }
+        //                else if( in_freq->lock < 168 ) {
+        //                    if (out_freq->lock < 72 || out_freq->lock >= 168)
+        //                    {
+        //                        return false;
+        //                    }
+        //                }
+        //                else if( in_freq->lock < 360 ) {
+        //                    if( out_freq->lock < 168 || out_freq->lock >= 360
+        //                    ) {
+        //                        return false;
+        //                    }
+        //                }
+        //                else if( in_freq->lock < 744 ) {
+        //                    if( out_freq->lock < 360 || out_freq->lock >= 744
+        //                    ) {
+        //                        return false;
+        //                    }
+        //                }
+        //                else if( in_freq->lock < 937 ) {
+        //                    if( out_freq->lock < 744 || out_freq->lock >= 937
+        //                    ) {
+        //                        return false;
+        //                    }
+        //                }
+        //                else {
+        //                    if( out_freq->lock < 937 ) {
+        //                        return false;
+        //                    }
+        //                }
+      }
+    }
+    ++out_sat_idx;
+  }
+
+  return true;
+}
+
+bool msg1005_equals(const rtcm_msg_1005 *lhs, const rtcm_msg_1005 *rhs) {
+  if (lhs->stn_id != rhs->stn_id) {
+    return false;
+  }
+  if (lhs->ITRF != rhs->ITRF) {
+    return false;
+  }
+  if (lhs->GPS_ind != rhs->GPS_ind) {
+    return false;
+  }
+  if (lhs->GLO_ind != rhs->GLO_ind) {
+    return false;
+  }
+  if (lhs->GAL_ind != rhs->GAL_ind) {
+    return false;
+  }
+  if (lhs->ref_stn_ind != rhs->ref_stn_ind) {
+    return false;
+  }
+  if (lhs->osc_ind != rhs->osc_ind) {
+    return false;
+  }
+  if (lhs->quart_cycle_ind != rhs->quart_cycle_ind) {
+    return false;
+  }
+  if (fabs(lhs->arp_x - rhs->arp_x) > 0.00005) {
+    return false;
+  }
+  if (fabs(lhs->arp_y - rhs->arp_y) > 0.00005) {
+    return false;
+  }
+  if (fabs(lhs->arp_z - rhs->arp_z) > 0.00005) {
+    return false;
+  }
+
+  return true;
+}
+
+bool msg1006_equals(const rtcm_msg_1006 *lhs, const rtcm_msg_1006 *rhs) {
+  if (fabs(lhs->ant_height - rhs->ant_height) > 0.00005) {
+    return false;
+  }
+
+  return msg1005_equals(&lhs->msg_1005, &rhs->msg_1005);
+}
+
+bool msg1007_equals(const rtcm_msg_1007 *lhs, const rtcm_msg_1007 *rhs) {
+  if (lhs->stn_id != rhs->stn_id) {
+    return false;
+  }
+  if (lhs->desc_count != rhs->desc_count) {
+    return false;
+  }
+  for (u8 ch = 0; ch < lhs->desc_count; ++ch) {
+    if (lhs->desc[ch] != rhs->desc[ch]) {
+      return false;
+    }
+  }
+  if (lhs->ant_id != rhs->ant_id) {
+    return false;
+  }
+
+  return true;
+}
+
+bool msg1008_equals(const rtcm_msg_1008 *lhs, const rtcm_msg_1008 *rhs) {
+  for (u8 ch = 0; ch < lhs->serial_count; ++ch) {
+    if (lhs->serial_num[ch] != rhs->serial_num[ch]) {
+      return false;
+    }
+  }
+
+  return msg1007_equals(&lhs->msg_1007, &rhs->msg_1007);
+}

--- a/c/test/rtcm_decoder_tests.h
+++ b/c/test/rtcm_decoder_tests.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (C) 2017 Swift Navigation Inc.
- * Contact: Jacob McNamee <jacob@swiftnav.com>
+ * Contact: Swift Navigation <dev@swiftnav.com>
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/c/test/rtcm_decoder_tests.h
+++ b/c/test/rtcm_decoder_tests.h
@@ -15,14 +15,14 @@
 
 #include <rtcm3_messages.h>
 
-static void test_rtcm_1001();
-static void test_rtcm_1002();
-static void test_rtcm_1003();
-static void test_rtcm_1004();
-static void test_rtcm_1005();
-static void test_rtcm_1006();
-static void test_rtcm_1007();
-static void test_rtcm_1008();
+static void test_rtcm_1001(void);
+static void test_rtcm_1002(void);
+static void test_rtcm_1003(void);
+static void test_rtcm_1004(void);
+static void test_rtcm_1005(void);
+static void test_rtcm_1006(void);
+static void test_rtcm_1007(void);
+static void test_rtcm_1008(void);
 
 bool msgobs_equals(const rtcm_obs_message *msg_in,
                    const rtcm_obs_message *msg_out);

--- a/c/test/rtcm_decoder_tests.h
+++ b/c/test/rtcm_decoder_tests.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2017 Swift Navigation Inc.
+ * Contact: Jacob McNamee <jacob@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef PIKSI_BUILDROOT_RTCM_DECODER_TESTS_H
+#define PIKSI_BUILDROOT_RTCM_DECODER_TESTS_H
+
+#include <rtcm3_messages.h>
+
+static void test_rtcm_1001();
+static void test_rtcm_1002();
+static void test_rtcm_1003();
+static void test_rtcm_1004();
+static void test_rtcm_1005();
+static void test_rtcm_1006();
+static void test_rtcm_1007();
+static void test_rtcm_1008();
+
+bool msgobs_equals(const rtcm_obs_message *msg_in,
+                   const rtcm_obs_message *msg_out);
+bool msg1005_equals(const rtcm_msg_1005 *lhs, const rtcm_msg_1005 *rhs);
+bool msg1006_equals(const rtcm_msg_1006 *lhs, const rtcm_msg_1006 *rhs);
+bool msg1007_equals(const rtcm_msg_1007 *lhs, const rtcm_msg_1007 *rhs);
+bool msg1008_equals(const rtcm_msg_1008 *lhs, const rtcm_msg_1008 *rhs);
+
+#endif // PIKSI_BUILDROOT_RTCM_DECODER_TESTS_H

--- a/c/test/rtcm_decoder_tests.h
+++ b/c/test/rtcm_decoder_tests.h
@@ -23,9 +23,13 @@ static void test_rtcm_1005(void);
 static void test_rtcm_1006(void);
 static void test_rtcm_1007(void);
 static void test_rtcm_1008(void);
+static void test_rtcm_1010(void);
+static void test_rtcm_1012(void);
 
 bool msgobs_equals(const rtcm_obs_message *msg_in,
                    const rtcm_obs_message *msg_out);
+bool msgobs_glo_equals(const rtcm_obs_message *msg_in,
+                       const rtcm_obs_message *msg_out);
 bool msg1005_equals(const rtcm_msg_1005 *lhs, const rtcm_msg_1005 *rhs);
 bool msg1006_equals(const rtcm_msg_1006 *lhs, const rtcm_msg_1006 *rhs);
 bool msg1007_equals(const rtcm_msg_1007 *lhs, const rtcm_msg_1007 *rhs);

--- a/c/test/rtcm_encoder.c
+++ b/c/test/rtcm_encoder.c
@@ -1,0 +1,610 @@
+/*
+ * Copyright (C) 2017 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include "rtcm_encoder.h"
+#include <math.h>
+
+/** Set bit field in buffer from an unsigned integer.
+ * Packs `len` bits into bit position `pos` from the start of the buffer.
+ * Maximum bit field length is 32 bits, i.e. `len <= 32`.
+ *
+ * \param buff
+ * \param pos Position in buffer of start of bit field in bits.
+ * \param len Length of bit field in bits.
+ * \param data Unsigned integer to be packed into bit field.
+ */
+void setbitu(u8 *buff, u32 pos, u32 len, u32 data) {
+  u32 mask = 1u << (len - 1);
+
+  if (len <= 0 || 32 < len)
+    return;
+
+  for (u32 i = pos; i < pos + len; i++, mask >>= 1) {
+    if (data & mask)
+      buff[i / 8] |= 1u << (7 - i % 8);
+    else
+      buff[i / 8] &= ~(1u << (7 - i % 8));
+  }
+}
+
+/** Set bit field in buffer from an unsigned integer.
+ * Packs `len` bits into bit position `pos` from the start of the buffer.
+ * Maximum bit field length is 32 bits, i.e. `len <= 32`.
+ *
+ * \param buff
+ * \param pos Position in buffer of start of bit field in bits.
+ * \param len Length of bit field in bits.
+ * \param data Unsigned integer to be packed into bit field.
+ */
+void setbitul(u8 *buff, u32 pos, u32 len, u64 data) {
+  u64 mask = ((u64)1) << (len - 1);
+
+  if (len <= 0 || 64 < len)
+    return;
+
+  for (u32 i = pos; i < pos + len; i++, mask >>= 1) {
+    if (data & mask)
+      buff[i / 8] |= ((u64)1) << (7 - i % 8);
+    else
+      buff[i / 8] &= ~(((u64)1) << (7 - i % 8));
+  }
+}
+
+/** Set bit field in buffer from a signed integer.
+ * Packs `len` bits into bit position `pos` from the start of the buffer.
+ * Maximum bit field length is 32 bits, i.e. `len <= 32`.
+ *
+ * \param buff
+ * \param pos Position in buffer of start of bit field in bits.
+ * \param len Length of bit field in bits.
+ * \param data Signed integer to be packed into bit field.
+ */
+void setbits(u8 *buff, u32 pos, u32 len, s32 data) {
+  setbitu(buff, pos, len, (u32)data);
+}
+
+/** Set bit field in buffer from a signed integer.
+ * Packs `len` bits into bit position `pos` from the start of the buffer.
+ * Maximum bit field length is 32 bits, i.e. `len <= 32`.
+ *
+ * \param buff
+ * \param pos Position in buffer of start of bit field in bits.
+ * \param len Length of bit field in bits.
+ * \param data Signed integer to be packed into bit field.
+ */
+void setbitsl(u8 *buff, u32 pos, u32 len, s64 data) {
+  setbitul(buff, pos, len, (u64)data);
+}
+
+/** Convert a lock time in seconds into a RTCMv3 Lock Time Indicator value.
+ * See RTCM 10403.1, Table 3.4-2.
+ *
+ * \param time Lock time in seconds.
+ * \return Lock Time Indicator value.
+ */
+static u8 to_lock_ind(u32 time) {
+  if (time < 24)
+    return time;
+  if (time < 72)
+    return (time + 24) / 2;
+  if (time < 168)
+    return (time + 120) / 4;
+  if (time < 360)
+    return (time + 408) / 8;
+  if (time < 744)
+    return (time + 1176) / 16;
+  if (time < 937)
+    return (time + 3096) / 32;
+  return 127;
+}
+
+void encode_basic_freq_data(const rtcm_freq_data *freq_data, const double freq,
+                            const double *l1_pr, u8 *buff, u16 *bit) {
+
+  /* Calculate GPS Integer L1 Pseudorange Modulus Ambiguity (DF014). */
+  u8 amb = (u8)(*l1_pr / PRUNIT_GPS);
+
+  /* Construct L1 pseudorange value as it would be transmitted (DF011). */
+  u32 calc_l1_pr = (u32)roundl((double)(*l1_pr - amb * PRUNIT_GPS) / 0.02);
+
+  /* Calculate GPS Pseudorange (DF011/DF016). */
+  u32 pr = (u32)roundl((freq_data->pseudorange - amb * PRUNIT_GPS) / 0.02);
+
+  double l1_prc = calc_l1_pr * 0.02 + amb * PRUNIT_GPS;
+
+  /* phaserange - L1 pseudorange */
+  double cp_pr = freq_data->carrier_phase - l1_prc / (CLIGHT / freq);
+
+  // TODO (anthony) If the pr and cp diverge, we should adjust the cp ambiguity and reset the lock time indicator
+
+  /* Calculate PhaseRange – L1 Pseudorange (DF012/DF018). */
+  s32 ppr = roundl(cp_pr * (CLIGHT / freq) / 0.0005);
+
+  if (fabs(freq - GPS_L1_FREQ) < 0.01) {
+    setbitu(buff, *bit, 1, 0);
+    *bit += 1;
+    setbitu(buff, *bit, 24, pr);
+    *bit += 24;
+  } else {
+    setbitu(buff, *bit, 2, 0);
+    *bit += 2;
+    setbits(buff, *bit, 14, (s32)pr - (s32)calc_l1_pr);
+    *bit += 14;
+  }
+  setbits(buff, *bit, 20, ppr);
+  *bit += 20;
+  setbitu(buff, *bit, 7,
+          freq_data->flags.valid_lock ? to_lock_ind(freq_data->lock) : 0);
+  *bit += 7;
+}
+
+void encode_basic_glo_freq_data(const rtcm_freq_data *freq_data, const double freq,
+                                const double *l1_pr, const u8 fcn, u8 *buff, u16 *bit) {
+
+  bool L1 = fabs(freq - GLO_L1_FREQ) < 0.01;
+  /* Calculate GPS Integer L1 Pseudorange Modulus Ambiguity (DF044). */
+  u8 amb = (u8)(*l1_pr / PRUNIT_GLO);
+
+  /* Construct L1 pseudorange value as it would be transmitted (DF041). */
+  u32 calc_l1_pr = (u32)roundl((double)(*l1_pr - amb * PRUNIT_GLO) / 0.02);
+
+  /* Calculate GLO Pseudorange (DF041/DF046). */
+  u32 pr = (u32)roundl((freq_data->pseudorange - amb * PRUNIT_GLO) / 0.02);
+
+  double l1_prc = calc_l1_pr * 0.02 + amb * PRUNIT_GLO;
+
+  double glo_freq = 0.0;
+  if (L1) {
+    glo_freq = freq + (fcn - 7) * GLO_L1_CH_OFFSET;
+  } else {
+    glo_freq = freq + (fcn - 7) * GLO_L2_CH_OFFSET;
+  }
+  /* phaserange - L1 pseudorange */
+  double cp_pr = freq_data->carrier_phase - l1_prc / (CLIGHT / glo_freq );
+
+  /* Calculate PhaseRange – L1 Pseudorange (DF042/DF048). */
+  s32 ppr = roundl(cp_pr * (CLIGHT / glo_freq) / 0.0005);
+
+  if (L1) {
+    setbitu(buff, *bit, 1, 0);
+    *bit += 1;
+    setbitu(buff, *bit, 5, fcn);
+    *bit += 5;
+    setbitu(buff, *bit, 25, pr);
+    *bit += 25;
+  } else {
+    setbitu(buff, *bit, 2, 0);
+    *bit += 2;
+    setbits(buff, *bit, 14, (s32)pr - (s32)calc_l1_pr);
+    *bit += 14;
+  }
+  setbits(buff, *bit, 20, ppr);
+  *bit += 20;
+  setbitu(buff, *bit, 7,
+          freq_data->flags.valid_lock ? to_lock_ind(freq_data->lock) : 0);
+  *bit += 7;
+}
+
+/** Write RTCM header for observation message types 1001..1004.
+ *
+ * The data message header will be written starting from byte zero of the
+ * buffer. If the buffer also contains a frame header then be sure to pass a
+ * pointer to the start of the data message rather than a pointer to the start
+ * of the frame buffer. The RTCM observation header is 8 bytes (64 bits) long.
+ *
+ * If the Synchronous GNSS Message Flag is set to `0`, it means that no further
+ * GNSS observables referenced to the same Epoch Time will be transmitted. This
+ * enables the receiver to begin processing the data immediately after decoding
+ * the message. If it is set to `1`, it means that the next message will
+ * contain observables of another GNSS source referenced to the same Epoch
+ * Time.
+ *
+ * Divergence-free Smoothing Indicator values:
+ *
+ * Indicator | Meaning
+ * --------- | ----------------------------------
+ *     0     | Divergence-free smoothing not used
+ *     1     | Divergence-free smoothing used
+ *
+ * GPS Smoothing Interval indicator values are listed in RTCM 10403.1 Table
+ * 3.4-4, reproduced here:
+ *
+ * Indicator | Smoothing Interval
+ * --------- | ------------------
+ *  000 (0)  |   No smoothing
+ *  001 (1)  |   < 30 s
+ *  010 (2)  |   30-60 s
+ *  011 (3)  |   1-2 min
+ *  100 (4)  |   2-4 min
+ *  101 (5)  |   4-8 min
+ *  110 (6)  |   >8 min
+ *  111 (7)  |   Unlimited
+ *
+ * \param header pointer to the obs header to encode
+ * \param num_sats number of satellites in message
+ * \param buff A pointer to the RTCM data message buffer.
+ */
+u16 rtcm3_write_header(const rtcm_obs_header *header, u8 num_sats, u8 *buff) {
+  u16 bit = 0;
+  setbitu(buff, bit, 12, header->msg_num);
+  bit += 12;
+  setbitu(buff, bit, 12, header->stn_id);
+  bit += 12;
+  setbitu(buff, bit, 30, (u32)round(header->tow * 1e3));
+  bit += 30;
+  setbitu(buff, bit, 1, header->sync);
+  bit += 1;
+  setbitu(buff, bit, 5, num_sats);
+  bit += 5;
+  setbitu(buff, bit, 1, header->div_free);
+  bit += 1;
+  setbitu(buff, bit, 3, header->smooth);
+  bit += 3;
+  return bit;
+}
+
+/** Write RTCM header for observation message types 1009..1012.
+ *
+ * The data message header will be written starting from byte zero of the
+ * buffer. If the buffer also contains a frame header then be sure to pass a
+ * pointer to the start of the data message rather than a pointer to the start
+ * of the frame buffer. The RTCM observation header is 8 bytes (61 bits) long.
+ *
+ * If the Synchronous GNSS Message Flag is set to `0`, it means that no further
+ * GNSS observables referenced to the same Epoch Time will be transmitted. This
+ * enables the receiver to begin processing the data immediately after decoding
+ * the message. If it is set to `1`, it means that the next message will
+ * contain observables of another GNSS source referenced to the same Epoch
+ * Time.
+ *
+ * Divergence-free Smoothing Indicator values:
+ *
+ * Indicator | Meaning
+ * --------- | ----------------------------------
+ *     0     | Divergence-free smoothing not used
+ *     1     | Divergence-free smoothing used
+ *
+ * GLO Smoothing Interval indicator values are listed in RTCM 10403.1 Table
+ * 3.4-4, reproduced here:
+ *
+ * Indicator | Smoothing Interval
+ * --------- | ------------------
+ *  000 (0)  |   No smoothing
+ *  001 (1)  |   < 30 s
+ *  010 (2)  |   30-60 s
+ *  011 (3)  |   1-2 min
+ *  100 (4)  |   2-4 min
+ *  101 (5)  |   4-8 min
+ *  110 (6)  |   >8 min
+ *  111 (7)  |   Unlimited
+ *
+ * \param header pointer to the obs header to encode
+ * \param num_sats number of satellites in message
+ * \param buff A pointer to the RTCM data message buffer.
+ */
+u16 rtcm3_write_glo_header(const rtcm_obs_header *header, u8 num_sats, u8 *buff) {
+  u16 bit = 0;
+  setbitu(buff, bit, 12, header->msg_num);
+  bit += 12;
+  setbitu(buff, bit, 12, header->stn_id);
+  bit += 12;
+  setbitu(buff, bit, 27, (u32)round(header->tow * 1e3));
+  bit += 27;
+  setbitu(buff, bit, 1, header->sync);
+  bit += 1;
+  setbitu(buff, bit, 5, num_sats);
+  bit += 5;
+  setbitu(buff, bit, 1, header->div_free);
+  bit += 1;
+  setbitu(buff, bit, 3, header->smooth);
+  bit += 3;
+  return bit;
+}
+
+u16 rtcm3_encode_1001(const rtcm_obs_message *msg_1001, u8 *buff) {
+  u16 bit = 64; /* Start at end of header. */
+
+  u8 num_sats = 0;
+  for (u8 i = 0; i < msg_1001->header.n_sat; i++) {
+    if (msg_1001->sats[i].obs[L1_FREQ].flags.valid_pr &&
+        msg_1001->sats[i].obs[L1_FREQ].flags.valid_cp) {
+      setbitu(buff, bit, 6, msg_1001->sats[i].svId);
+      bit += 6;
+      encode_basic_freq_data(&msg_1001->sats[i].obs[L1_FREQ], GPS_L1_FREQ,
+                             &msg_1001->sats[i].obs[L1_FREQ].pseudorange,
+                             buff, &bit);
+      ++num_sats;
+    }
+  }
+
+  rtcm3_write_header(&msg_1001->header, num_sats, buff);
+
+  /* Round number of bits up to nearest whole byte. */
+  return (bit + 7) / 8;
+}
+
+/** Encode an RTCMv3 message type 1002 (Extended L1-Only GPS RTK Observables)
+ * Message type 1002 has length `64 + n_sat*74` bits. Returned message length
+ * is rounded up to the nearest whole byte.
+ *
+ * \param buff A pointer to the RTCM data message buffer.
+ * \param id Reference station ID (DF003).
+ * \param t GPS time of epoch (DF004).
+ * \param n_sat Number of GPS satellites included in the message (DF006).
+ * \param nm Struct containing the observation.
+ * \param sync Synchronous GNSS Flag (DF005).
+ * \return The message length in bytes.
+ */
+u16 rtcm3_encode_1002(const rtcm_obs_message *msg_1002, u8 *buff) {
+  u16 bit = 64; /* Start at end of header. */
+
+  u8 num_sats = 0;
+  for (u8 i = 0; i < msg_1002->header.n_sat; i++) {
+    if (msg_1002->sats[i].obs[L1_FREQ].flags.valid_pr &&
+        msg_1002->sats[i].obs[L1_FREQ].flags.valid_cp) {
+      setbitu(buff, bit, 6, msg_1002->sats[i].svId);
+      bit += 6;
+      encode_basic_freq_data(&msg_1002->sats[i].obs[L1_FREQ], GPS_L1_FREQ,
+                             &msg_1002->sats[i].obs[L1_FREQ].pseudorange,
+                             buff, &bit);
+
+      /* Calculate GPS Integer L1 Pseudorange Modulus Ambiguity (DF014). */
+      u8 amb =
+        (u8)(msg_1002->sats[i].obs[L1_FREQ].pseudorange / PRUNIT_GPS);
+
+      setbitu(buff, bit, 8, amb);
+      bit += 8;
+      setbitu(buff, bit, 8,
+              (u8)roundl(msg_1002->sats[i].obs[L1_FREQ].cnr * 4.0));
+      bit += 8;
+      ++num_sats;
+    }
+  }
+
+  rtcm3_write_header(&msg_1002->header, num_sats, buff);
+
+  /* Round number of bits up to nearest whole byte. */
+  return (bit + 7) / 8;
+}
+
+u16 rtcm3_encode_1003(const rtcm_obs_message *msg_1003, u8 *buff) {
+  u16 bit = 64; /* Start at end of header. */
+
+  u8 num_sats = 0;
+  for (u8 i = 0; i < msg_1003->header.n_sat; i++) {
+    flag_bf l1_flags = msg_1003->sats[i].obs[L1_FREQ].flags;
+    flag_bf l2_flags = msg_1003->sats[i].obs[L2_FREQ].flags;
+    if (l1_flags.valid_pr && l1_flags.valid_cp && l2_flags.valid_pr &&
+        l2_flags.valid_cp) {
+      setbitu(buff, bit, 6, msg_1003->sats[i].svId);
+      bit += 6;
+      encode_basic_freq_data(&msg_1003->sats[i].obs[L1_FREQ], GPS_L1_FREQ,
+                             &msg_1003->sats[i].obs[L1_FREQ].pseudorange,
+                             buff, &bit);
+      encode_basic_freq_data(&msg_1003->sats[i].obs[L2_FREQ], GPS_L2_FREQ,
+                             &msg_1003->sats[i].obs[L1_FREQ].pseudorange,
+                             buff, &bit);
+      ++num_sats;
+    }
+  }
+
+  rtcm3_write_header(&msg_1003->header, num_sats, buff);
+
+  /* Round number of bits up to nearest whole byte. */
+  return (bit + 7) / 8;
+}
+
+u16 rtcm3_encode_1004(const rtcm_obs_message *msg_1004, u8 *buff) {
+  u16 bit = 64; /* Start at end of header. */
+
+  u8 num_sats = 0;
+  for (u8 i = 0; i < msg_1004->header.n_sat; i++) {
+    flag_bf l1_flags = msg_1004->sats[i].obs[L1_FREQ].flags;
+    flag_bf l2_flags = msg_1004->sats[i].obs[L2_FREQ].flags;
+    if (l1_flags.valid_pr && l1_flags.valid_cp && l2_flags.valid_pr &&
+        l2_flags.valid_cp) {
+      setbitu(buff, bit, 6, msg_1004->sats[i].svId);
+      bit += 6;
+      encode_basic_freq_data(&msg_1004->sats[i].obs[L1_FREQ], GPS_L1_FREQ,
+                             &msg_1004->sats[i].obs[L1_FREQ].pseudorange,
+                             buff, &bit);
+
+      /* Calculate GPS Integer L1 Pseudorange Modulus Ambiguity (DF014). */
+      u8 amb =
+        (u8)(msg_1004->sats[i].obs[L1_FREQ].pseudorange / PRUNIT_GPS);
+
+      setbitu(buff, bit, 8, amb);
+      bit += 8;
+      setbitu(buff, bit, 8,
+              (u8)roundl(msg_1004->sats[i].obs[L1_FREQ].cnr * 4.0));
+      bit += 8;
+
+      encode_basic_freq_data(&msg_1004->sats[i].obs[L2_FREQ], GPS_L2_FREQ,
+                             &msg_1004->sats[i].obs[L1_FREQ].pseudorange,
+                             buff, &bit);
+      setbitu(buff, bit, 8,
+              (u8)roundl(msg_1004->sats[i].obs[L2_FREQ].cnr * 4.0));
+      bit += 8;
+      ++num_sats;
+    }
+  }
+
+  rtcm3_write_header(&msg_1004->header, num_sats, buff);
+
+  /* Round number of bits up to nearest whole byte. */
+  return (bit + 7) / 8;
+}
+
+u16 rtcm3_encode_1005_base(const rtcm_msg_1005 *msg_1005, u8 *buff,
+                           u16 *bit) {
+  setbitu(buff, *bit, 12, msg_1005->stn_id);
+  *bit += 12;
+  setbitu(buff, *bit, 6, msg_1005->ITRF);
+  *bit += 6;
+  setbitu(buff, *bit, 1, msg_1005->GPS_ind);
+  *bit += 1;
+  setbitu(buff, *bit, 1, msg_1005->GLO_ind);
+  *bit += 1;
+  setbitu(buff, *bit, 1, msg_1005->GAL_ind);
+  *bit += 1;
+  setbitu(buff, *bit, 1, msg_1005->ref_stn_ind);
+  *bit += 1;
+  setbitsl(buff, *bit, 38, (s64)roundl(msg_1005->arp_x * 10000.0));
+  *bit += 38;
+  setbitu(buff, *bit, 1, msg_1005->osc_ind);
+  *bit += 1;
+  setbitu(buff, *bit, 1, 0);
+  *bit += 1;
+  setbitsl(buff, *bit, 38, (s64)roundl(msg_1005->arp_y * 10000.0));
+  *bit += 38;
+  setbitu(buff, *bit, 2, msg_1005->quart_cycle_ind);
+  *bit += 2;
+  setbitsl(buff, *bit, 38, (s64)roundl(msg_1005->arp_z * 10000.0));
+  *bit += 38;
+
+  /* Round number of bits up to nearest whole byte. */
+  return (*bit + 7) / 8;
+}
+
+u16 rtcm3_encode_1005(const rtcm_msg_1005 *msg_1005, u8 *buff) {
+  u16 bit = 0;
+  setbitu(buff, bit, 12, 1005);
+  bit += 12;
+  return rtcm3_encode_1005_base(msg_1005, buff, &bit);
+}
+
+u16 rtcm3_encode_1006(const rtcm_msg_1006 *msg_1006, u8 *buff) {
+  u16 bit = 0;
+  setbitu(buff, bit, 12, 1006);
+  bit += 12;
+  rtcm3_encode_1005_base(&msg_1006->msg_1005, buff, &bit);
+  setbitu(buff, bit, 16, (u16)roundl(msg_1006->ant_height * 10000.0));
+  bit += 16;
+
+  /* Round number of bits up to nearest whole byte. */
+  return (bit + 7) / 8;
+}
+
+u16 rtcm3_encode_1007_base(const rtcm_msg_1007 *msg_1007, u8 *buff,
+                           u16 *bit) {
+  setbitu(buff, *bit, 12, msg_1007->stn_id);
+  *bit += 12;
+  setbitu(buff, *bit, 8, msg_1007->desc_count);
+  *bit += 8;
+  for (u8 i = 0; i < msg_1007->desc_count; ++i) {
+    setbitu(buff, *bit, 8, msg_1007->desc[i]);
+    *bit += 8;
+  }
+  setbitu(buff, *bit, 8, msg_1007->ant_id);
+  *bit += 8;
+
+  /* Round number of bits up to nearest whole byte. */
+  return (*bit + 7) / 8;
+}
+
+u16 rtcm3_encode_1007(const rtcm_msg_1007 *msg_1007, u8 *buff) {
+  u16 bit = 0;
+  setbitu(buff, bit, 12, 1007);
+  bit += 12;
+  return rtcm3_encode_1007_base(msg_1007, buff, &bit);
+}
+
+u16 rtcm3_encode_1008(const rtcm_msg_1008 *msg_1008, u8 *buff) {
+  u16 bit = 0;
+  setbitu(buff, bit, 12, 1008);
+  bit += 12;
+  rtcm3_encode_1007_base(&msg_1008->msg_1007, buff, &bit);
+  setbitu(buff, bit, 8, msg_1008->serial_count);
+  bit += 8;
+  for (u8 i = 0; i < msg_1008->serial_count; ++i) {
+    setbitu(buff, bit, 8, msg_1008->serial_num[i]);
+    bit += 8;
+  }
+
+  /* Round number of bits up to nearest whole byte. */
+  return (bit + 7) / 8;
+}
+
+u16 rtcm3_encode_1010(const rtcm_obs_message *msg_1010, u8 *buff){
+  u16 bit = 61; /* Start at end of header. */
+
+  u8 num_sats = 0;
+  for (u8 i = 0; i < msg_1010->header.n_sat; i++) {
+    if (msg_1010->sats[i].obs[L1_FREQ].flags.valid_pr &&
+        msg_1010->sats[i].obs[L1_FREQ].flags.valid_cp) {
+      const rtcm_sat_data *sat_obs = &msg_1010->sats[i];
+      setbitu(buff, bit, 6, sat_obs->svId);
+      bit += 6;
+      encode_basic_glo_freq_data(&sat_obs->obs[L1_FREQ], GLO_L1_FREQ,
+                                 &sat_obs->obs[L1_FREQ].pseudorange, sat_obs->fcn,
+                                 buff, &bit);
+
+      /* Calculate GPS Integer L1 Pseudorange Modulus Ambiguity (DF014). */
+      u8 amb =
+        (u8)(sat_obs->obs[L1_FREQ].pseudorange / PRUNIT_GLO);
+
+      setbitu(buff, bit, 7, amb);
+      bit += 7;
+      setbitu(buff, bit, 8,
+              (u8)roundl(sat_obs->obs[L1_FREQ].cnr * 4.0));
+      bit += 8;
+      ++num_sats;
+    }
+  }
+
+  rtcm3_write_glo_header(&msg_1010->header, num_sats, buff);
+
+  /* Round number of bits up to nearest whole byte. */
+  return (bit + 7) / 8;
+}
+
+u16 rtcm3_encode_1012(const rtcm_obs_message *msg_1012, u8 *buff){
+  u16 bit = 61; /* Start at end of header. */
+
+  u8 num_sats = 0;
+  for (u8 i = 0; i < msg_1012->header.n_sat; i++) {
+    flag_bf l1_flags = msg_1012->sats[i].obs[L1_FREQ].flags;
+    flag_bf l2_flags = msg_1012->sats[i].obs[L2_FREQ].flags;
+    if (l1_flags.valid_pr && l1_flags.valid_cp && l2_flags.valid_pr &&
+        l2_flags.valid_cp) {
+      const rtcm_sat_data *sat_obs = &msg_1012->sats[i];
+      setbitu(buff, bit, 6, sat_obs->svId);
+      bit += 6;
+      encode_basic_glo_freq_data(&sat_obs->obs[L1_FREQ], GLO_L1_FREQ,
+                                 &sat_obs->obs[L1_FREQ].pseudorange, sat_obs->fcn,
+                                 buff, &bit);
+
+      /* Calculate GLO Integer L1 Pseudorange Modulus Ambiguity (DF014). */
+      u8 amb =
+        (u8)(sat_obs->obs[L1_FREQ].pseudorange / PRUNIT_GLO);
+
+      setbitu(buff, bit, 8, amb);
+      bit += 8;
+      setbitu(buff, bit, 8,
+              (u8)roundl(sat_obs->obs[L1_FREQ].cnr * 4.0));
+      bit += 8;
+
+      encode_basic_glo_freq_data(&sat_obs->obs[L2_FREQ], GLO_L2_FREQ,
+                                 &sat_obs->obs[L1_FREQ].pseudorange, sat_obs->fcn,
+                                 buff, &bit);
+      setbitu(buff, bit, 8,
+              (u8)roundl(sat_obs->obs[L2_FREQ].cnr * 4.0));
+      bit += 8;
+      ++num_sats;
+    }
+  }
+
+  rtcm3_write_glo_header(&msg_1012->header, num_sats, buff);
+
+  /* Round number of bits up to nearest whole byte. */
+  return (bit + 7) / 8;
+}

--- a/c/test/rtcm_encoder.h
+++ b/c/test/rtcm_encoder.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2017 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/* These encoder functions are provided to allow for easier unit testing however they are not robust to be used
+ * in production. Before using with real data, we would need to handle ambiguity rollover and code carrier
+ * divergance at least
+ */
+
+#ifndef LIBRTCM_RTCM_ENCODER_H
+#define LIBRTCM_RTCM_ENCODER_H
+
+#include <rtcm3_messages.h>
+
+void setbitu(u8 *buff, u32 pos, u32 len, u32 data);
+void setbitul(u8 *buff, u32 pos, u32 len, u64 data);
+void setbits(u8 *buff, u32 pos, u32 len, s32 data);
+void setbitsl(u8 *buff, u32 pos, u32 len, s64 data);
+
+u16 rtcm3_write_header(const rtcm_obs_header *header, u8 num_sats, u8 *buff);
+
+u16 rtcm3_encode_1001(const rtcm_obs_message *msg_1001, u8 *buff);
+u16 rtcm3_encode_1002(const rtcm_obs_message *msg_1002, u8 *buff);
+u16 rtcm3_encode_1003(const rtcm_obs_message *msg_1003, u8 *buff);
+u16 rtcm3_encode_1004(const rtcm_obs_message *msg_1004, u8 *buff);
+u16 rtcm3_encode_1005(const rtcm_msg_1005 *msg_1005, u8 *buff);
+u16 rtcm3_encode_1006(const rtcm_msg_1006 *msg_1006, u8 *buff);
+u16 rtcm3_encode_1007(const rtcm_msg_1007 *msg_1007, u8 *buff);
+u16 rtcm3_encode_1008(const rtcm_msg_1008 *msg_1008, u8 *buff);
+u16 rtcm3_encode_1010(const rtcm_obs_message *msg_1010, u8 *buff);
+u16 rtcm3_encode_1012(const rtcm_obs_message *msg_1012, u8 *buff);
+
+#endif //LIBRTCM_RTCM_ENCODER_H

--- a/travis.sh
+++ b/travis.sh
@@ -7,17 +7,19 @@ set -o errexit
 set -o pipefail
 
 function build_haskell () {
-    cd ./haskell
+    cd haskell
     stack build --test
     cd ../
 }
 
 function build_c() {
-    cd ./c
-    mkdir ./build
-    cd ./build
+    cd c
+    mkdir build
+    cd build
     cmake ../
     make -j4
+    cd ../
+    cd ../
 }
 
 build_c

--- a/travis.sh
+++ b/travis.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Run Travis setup
+
+set -x
+set -o errexit
+set -o pipefail
+
+function build_haskell () {
+    cd ./haskell
+    stack build --test
+    cd ../
+}
+
+function build_c() {
+    cd ./c
+    mkdir ./build
+    cd ./build
+    cmake ../
+    make -j4
+}
+
+build_c
+build_haskell


### PR DESCRIPTION
Ok, think this initial cut of the c librtcm is ready for review. The code I've not tried to adapt from what is in piksi_buildroot, I'll modify that in a  subsequent PR. What I wanted with this PR was to get the following initial functionality

- Define RTCM message structs
- Define decoding routines for supported RTCM messages
- Enable unit tests from piksi buildroot for decoders
- Define cmake for c build within repo
- Modify travis to support build.

For review, I'd especially appreciate review on the following
- Cmake additions - particularly compiler flags used
- Travis modifications
- Structure of the repo

@mfine @peddie @fnoble 