### PR TITLE
GLO amb is only 7 bits not 8

### DIFF
--- a/c/src/rtcm3_decode.c
+++ b/c/src/rtcm3_decode.c
@@ -651,8 +651,8 @@ int8_t rtcm3_decode_1012(const uint8_t *buff, rtcm_obs_message *msg_1012)
     decode_basic_glo_l1_freq_data(buff, &bit, l1_freq_data, &l1_pr,
                                   &phr_pr_diff, &msg_1012->sats[i].fcn);
 
-    uint8_t amb = getbitu(buff, bit, 8);
-    bit += 8;
+    uint8_t amb = getbitu(buff, bit, 7);
+    bit += 7;
     l1_freq_data->cnr = 0.25 * getbitu(buff, bit, 8);
     bit += 8;
     l1_freq_data->flags.valid_cnr = 1;

--- a/c/test/rtcm_encoder.c
+++ b/c/test/rtcm_encoder.c
@@ -608,8 +608,8 @@ uint16_t rtcm3_encode_1012(const rtcm_obs_message *msg_1012, uint8_t *buff)
       uint8_t amb =
         (uint8_t)(sat_obs->obs[L1_FREQ].pseudorange / PRUNIT_GLO);
 
-      setbitu(buff, bit, 8, amb);
-      bit += 8;
+      setbitu(buff, bit, 7, amb);
+      bit += 7;
       setbitu(buff, bit, 8,
               (uint8_t)roundl(sat_obs->obs[L1_FREQ].cnr * 4.0));
       bit += 8;


### PR DESCRIPTION
Currently we're using 8 bits for the 1012 amb field, this is only a 7 bit field