### PR TITLE
Define GLO cpb units in RTCM message struct as meters

### DIFF
--- a/c/include/rtcm3_messages.h
+++ b/c/include/rtcm3_messages.h
@@ -97,10 +97,10 @@ typedef struct {
   uint16_t stn_id;
   uint8_t bias_indicator;
   uint8_t fdma_signal_mask;
-  double L1_CA_cpb;
-  double L1_P_cpb;
-  double L2_CA_cpb;
-  double L2_P_cpb;
+  double L1_CA_cpb_meter;
+  double L1_P_cpb_meter;
+  double L2_CA_cpb_meter;
+  double L2_P_cpb_meter;
 } rtcm_msg_1230;
 
 #endif /* PIKSI_BUILDROOT_RTCM3_MESSAGES_H_H */

--- a/c/src/rtcm3_decode.c
+++ b/c/src/rtcm3_decode.c
@@ -721,19 +721,19 @@ int8_t rtcm3_decode_1230(const uint8_t *buff, rtcm_msg_1230 *msg_1230)
   msg_1230->fdma_signal_mask = getbitu(buff, bit, 4);
   bit += 4;
   if(msg_1230->fdma_signal_mask & 0x08) {
-    msg_1230->L1_CA_cpb = getbits(buff, bit, 16) * 0.02;
+    msg_1230->L1_CA_cpb_meter = getbits(buff, bit, 16) * 0.02;
     bit += 16;
   }
   if(msg_1230->fdma_signal_mask & 0x04) {
-    msg_1230->L1_P_cpb = getbits(buff, bit, 16) * 0.02;
+    msg_1230->L1_P_cpb_meter = getbits(buff, bit, 16) * 0.02;
     bit += 16;
   }
   if(msg_1230->fdma_signal_mask & 0x02) {
-    msg_1230->L2_CA_cpb = getbits(buff, bit, 16) * 0.02;
+    msg_1230->L2_CA_cpb_meter = getbits(buff, bit, 16) * 0.02;
     bit += 16;
   }
   if(msg_1230->fdma_signal_mask & 0x01) {
-    msg_1230->L2_P_cpb = getbits(buff, bit, 16) * 0.02;
+    msg_1230->L2_P_cpb_meter = getbits(buff, bit, 16) * 0.02;
     bit += 16;
   }
 

--- a/c/test/rtcm_decoder_tests.c
+++ b/c/test/rtcm_decoder_tests.c
@@ -512,10 +512,10 @@ void test_rtcm_1230(void)
   msg1230.stn_id = 22;
   msg1230.bias_indicator = 0;
   msg1230.fdma_signal_mask = 0x0F;
-  msg1230.L1_CA_cpb = 35.32;
-  msg1230.L1_P_cpb = 66.32;
-  msg1230.L2_CA_cpb = 34.33;
-  msg1230.L2_P_cpb = -29.32;
+  msg1230.L1_CA_cpb_meter = 35.32;
+  msg1230.L1_P_cpb_meter = 66.32;
+  msg1230.L2_CA_cpb_meter = 34.33;
+  msg1230.L2_P_cpb_meter = -29.32;
 
   uint8_t buff[1024];
   memset(buff,0,1024);
@@ -938,29 +938,29 @@ bool msg1230_equals(const rtcm_msg_1230 *lhs, const rtcm_msg_1230 *rhs)
   }
 
   if (lhs->fdma_signal_mask & 0x08) {
-    if (fabs(lhs->L1_CA_cpb - rhs->L1_CA_cpb) > 0.015 ) {
-      printf("1230 L1 CA code phase bias not equal %5.3f %5.3f\n",lhs->L1_CA_cpb,rhs->L1_CA_cpb);
+    if (fabs(lhs->L1_CA_cpb_meter - rhs->L1_CA_cpb_meter) > 0.015 ) {
+      printf("1230 L1 CA code phase bias not equal %5.3f %5.3f\n",lhs->L1_CA_cpb_meter,rhs->L1_CA_cpb_meter);
       return false;
     }
   }
 
   if (lhs->fdma_signal_mask & 0x04) {
-    if (fabs(lhs->L1_P_cpb - rhs->L1_P_cpb) > 0.015) {
-      printf("1230 L1 P code phase bias not equal %5.3f %5.3f\n",lhs->L1_P_cpb,rhs->L1_P_cpb);
+    if (fabs(lhs->L1_P_cpb_meter - rhs->L1_P_cpb_meter) > 0.015) {
+      printf("1230 L1 P code phase bias not equal %5.3f %5.3f\n",lhs->L1_P_cpb_meter,rhs->L1_P_cpb_meter);
       return false;
     }
   }
 
   if (lhs->fdma_signal_mask & 0x02) {
-    if (fabs(lhs->L2_CA_cpb - rhs->L2_CA_cpb) > 0.015) {
-      printf("1230 L2 CA code phase bias not equal %5.3f %5.3f\n",lhs->L2_CA_cpb,rhs->L2_CA_cpb);
+    if (fabs(lhs->L2_CA_cpb_meter - rhs->L2_CA_cpb_meter) > 0.015) {
+      printf("1230 L2 CA code phase bias not equal %5.3f %5.3f\n",lhs->L2_CA_cpb_meter,rhs->L2_CA_cpb_meter);
       return false;
     }
   }
 
   if (lhs->fdma_signal_mask & 0x01) {
-    if (fabs(lhs->L2_P_cpb - rhs->L2_P_cpb) > 0.015) {
-      printf("1230 L2 P code phase bias not equal %5.3f %5.3f\n",lhs->L2_P_cpb,rhs->L2_P_cpb);
+    if (fabs(lhs->L2_P_cpb_meter - rhs->L2_P_cpb_meter) > 0.015) {
+      printf("1230 L2 P code phase bias not equal %5.3f %5.3f\n",lhs->L2_P_cpb_meter,rhs->L2_P_cpb_meter);
       return false;
     }
   }

--- a/c/test/rtcm_encoder.c
+++ b/c/test/rtcm_encoder.c
@@ -645,22 +645,22 @@ uint16_t rtcm3_encode_1230(const rtcm_msg_1230 *msg_1230, uint8_t *buff)
   setbitu(buff, bit, 4, msg_1230->fdma_signal_mask);
   bit += 4;
   if(msg_1230->fdma_signal_mask & 0x08) {
-    int16_t bias = round(msg_1230->L1_CA_cpb * 50);
+    int16_t bias = round(msg_1230->L1_CA_cpb_meter * 50);
     setbits(buff, bit, 16, bias);
     bit += 16;
   }
   if(msg_1230->fdma_signal_mask & 0x04) {
-    int16_t bias = round(msg_1230->L1_P_cpb * 50);
+    int16_t bias = round(msg_1230->L1_P_cpb_meter * 50);
     setbits(buff, bit, 16, bias);
     bit += 16;
   }
   if(msg_1230->fdma_signal_mask & 0x02) {
-    int16_t bias = round(msg_1230->L2_CA_cpb * 50);
+    int16_t bias = round(msg_1230->L2_CA_cpb_meter * 50);
     setbits(buff, bit, 16, bias);
     bit += 16;
   }
   if(msg_1230->fdma_signal_mask & 0x01) {
-    int16_t bias = round(msg_1230->L2_P_cpb * 50);
+    int16_t bias = round(msg_1230->L2_P_cpb_meter * 50);
     setbits(buff, bit, 16, bias);
     bit += 16;
   }


### PR DESCRIPTION
Explicitly mark RTCM GLonass code phase bias values as meters to avoid confusion