### PR TITLE
Add 1033 support

### DIFF
--- a/c/include/rtcm3_decode.h
+++ b/c/include/rtcm3_decode.h
@@ -25,6 +25,7 @@ int8_t rtcm3_decode_1007(const uint8_t *buff, rtcm_msg_1007 *msg_1007);
 int8_t rtcm3_decode_1008(const uint8_t *buff, rtcm_msg_1008 *msg_1008);
 int8_t rtcm3_decode_1010(const uint8_t *buff, rtcm_obs_message *msg_1010);
 int8_t rtcm3_decode_1012(const uint8_t *buff, rtcm_obs_message *msg_1012);
+int8_t rtcm3_decode_1033(const uint8_t *buff, rtcm_msg_1033 *msg_1033);
 int8_t rtcm3_decode_1230(const uint8_t *buff, rtcm_msg_1230 *msg_1230);
 
 #endif /* SWIFTNAV_RTCM3_DECODE_H */

--- a/c/include/rtcm3_messages.h
+++ b/c/include/rtcm3_messages.h
@@ -103,4 +103,19 @@ typedef struct {
   double L2_P_cpb_meter;
 } rtcm_msg_1230;
 
+typedef struct {
+  uint16_t stn_id;
+  uint8_t antenna_desc_counter;
+  char antenna_descriptor[32];
+  uint8_t antenna_setup_ID;
+  uint8_t antenna_serial_num_counter;
+  char antenna_serial_num[32];
+  uint8_t rcv_descriptor_counter;
+  char rcv_descriptor[32];
+  uint8_t rcv_fw_counter;
+  char rcv_fw_version[32];
+  uint8_t rcv_serial_num_counter;
+  char rcv_serial_num[32];
+} rtcm_msg_1033;
+
 #endif /* PIKSI_BUILDROOT_RTCM3_MESSAGES_H_H */

--- a/c/src/rtcm3_decode.c
+++ b/c/src/rtcm3_decode.c
@@ -694,6 +694,68 @@ int8_t rtcm3_decode_1012(const uint8_t *buff, rtcm_obs_message *msg_1012)
   return 0;
 }
 
+/** Decode an RTCMv3 message type 1033 (Rcv and Ant descriptor)
+ *
+ * \param buff The input data buffer
+ * \param RTCM message struct
+ * \return If valid then return 0.
+ *         Returns a negative number if the message is invalid:
+ *          - `-1` : Message type mismatch
+ */
+int8_t rtcm3_decode_1033(const uint8_t *buff, rtcm_msg_1033 *msg_1033)
+{
+  uint16_t bit = 0;
+  uint16_t msg_num = getbitu(buff, bit, 12);
+  bit += 12;
+
+  if (msg_num != 1033)
+    /* Unexpected message type. */
+    return -1;
+
+  msg_1033->stn_id = getbitu(buff, bit, 12);
+  bit += 12;
+
+  msg_1033->antenna_desc_counter = getbitu(buff, bit, 8);
+  bit += 8;
+  for (uint8_t i = 0; i < msg_1033->antenna_desc_counter; ++i) {
+    msg_1033->antenna_descriptor[i] = getbitu(buff, bit, 8);
+    bit += 8;
+  }
+
+  msg_1033->antenna_setup_ID = getbitu(buff, bit, 8);
+  bit += 8;
+
+  msg_1033->antenna_serial_num_counter = getbitu(buff, bit, 8);
+  bit += 8;
+  for (uint8_t i = 0; i < msg_1033->antenna_serial_num_counter; ++i) {
+    msg_1033->antenna_serial_num[i] = getbitu(buff, bit, 8);
+    bit += 8;
+  }
+
+  msg_1033->rcv_descriptor_counter = getbitu(buff, bit, 8);
+  bit += 8;
+  for (uint8_t i = 0; i < msg_1033->rcv_descriptor_counter; ++i) {
+    msg_1033->rcv_descriptor[i] = getbitu(buff, bit, 8);
+    bit += 8;
+  }
+
+  msg_1033->rcv_fw_counter = getbitu(buff, bit, 8);
+  bit += 8;
+  for (uint8_t i = 0; i < msg_1033->rcv_fw_counter; ++i) {
+    msg_1033->rcv_fw_version[i] = getbitu(buff, bit, 8);
+    bit += 8;
+  }
+
+  msg_1033->rcv_serial_num_counter = getbitu(buff, bit, 8);
+  bit += 8;
+  for (uint8_t i = 0; i < msg_1033->rcv_serial_num_counter; ++i) {
+    msg_1033->rcv_serial_num[i] = getbitu(buff, bit, 8);
+    bit += 8;
+  }
+
+  return 0;
+}
+
 /** Decode an RTCMv3 message type 1230 (Code-Phase Bias Message)
  *
  * \param buff The input data buffer

--- a/c/test/rtcm_decoder_tests.c
+++ b/c/test/rtcm_decoder_tests.c
@@ -32,6 +32,7 @@ int main(void)
   test_rtcm_1010();
   test_rtcm_1012();
   test_rtcm_1230();
+  test_rtcm_1033();
 }
 
 void test_rtcm_1001(void)
@@ -357,7 +358,7 @@ void test_rtcm_1008(void)
   strcpy(msg1008.msg_1007.desc, "Something without 30 chars.");
   msg1008.msg_1007.ant_id = 1;
   msg1008.serial_count = 9;
-  strcpy(msg1008.serial_num, "123456789");
+  strncpy(msg1008.serial_num, "123456789",32);
 
   uint8_t buff[1024];
   memset(buff,0,1024);
@@ -503,6 +504,32 @@ void test_rtcm_1012(void)
   int8_t ret = rtcm3_decode_1012(buff, &msg1012_out);
 
   assert(ret == 0 && msgobs_glo_equals(&msg1012, &msg1012_out));
+}
+
+void test_rtcm_1033(void) {
+  rtcm_msg_1033 msg1033;
+  msg1033.stn_id = 555;
+  msg1033.antenna_desc_counter = 5;
+  strncpy(msg1033.antenna_descriptor, "hello", 32);
+  msg1033.antenna_setup_ID = 7;
+  msg1033.antenna_serial_num_counter = 3;
+  strncpy(msg1033.antenna_serial_num, "777", 32);
+  msg1033.rcv_descriptor_counter = 9;
+  strncpy(msg1033.rcv_descriptor, "LEI - IGS", 32);
+  msg1033.rcv_fw_counter = 6;
+  strncpy(msg1033.rcv_fw_version, "1.2.14", 32);
+  msg1033.rcv_serial_num_counter = 20;
+  strncpy(msg1033.rcv_serial_num, "66666666666666666666", 32);
+
+  uint8_t buff[1024];
+  memset(buff,0,1024);
+  rtcm3_encode_1033(&msg1033, buff);
+
+  rtcm_msg_1033 msg1033_out;
+  int8_t ret = rtcm3_decode_1033(buff, &msg1033_out);
+
+  assert(ret == 0 && msg1033_equals(&msg1033, &msg1033_out));
+
 }
 
 void test_rtcm_1230(void)
@@ -918,6 +945,47 @@ bool msg1008_equals(const rtcm_msg_1008 *lhs, const rtcm_msg_1008 *rhs)
   }
 
   return msg1007_equals(&lhs->msg_1007, &rhs->msg_1007);
+}
+
+bool msg1033_equals(const rtcm_msg_1033 *lhs, const rtcm_msg_1033 *rhs)
+{
+  if (lhs->stn_id != rhs->stn_id) {
+    return false;
+  }
+  if (lhs->antenna_desc_counter != rhs->antenna_desc_counter) {
+    return false;
+  }
+  if (strncmp(lhs->antenna_descriptor, rhs->antenna_descriptor, lhs->antenna_desc_counter) != 0) {
+    return false;
+  }
+  if (lhs->antenna_setup_ID != rhs->antenna_setup_ID) {
+    return false;
+  }
+  if (lhs->antenna_serial_num != rhs->antenna_serial_num) {
+    return false;
+  }
+  if (strncmp(lhs->antenna_serial_num, rhs->antenna_serial_num, lhs->antenna_serial_num_counter) != 0) {
+    return false;
+  }
+  if (lhs->rcv_descriptor_counter != rhs->rcv_descriptor_counter) {
+    return false;
+  }
+  if (strncmp(lhs->rcv_descriptor, rhs->rcv_descriptor, lhs->rcv_descriptor_counter) != 0) {
+    return false;
+  }
+  if (lhs->rcv_fw_counter != rhs->rcv_fw_counter) {
+    return false;
+  }
+  if (strncmp(lhs->rcv_fw_version, rhs->rcv_fw_version, lhs->rcv_fw_counter) != 0) {
+    return false;
+  }
+  if (lhs->rcv_serial_num_counter != rhs->rcv_serial_num_counter) {
+    return false;
+  }
+  if (strncmp(lhs->rcv_serial_num, rhs->rcv_serial_num, lhs->rcv_serial_num_counter) != 0) {
+    return false;
+  }
+  return true;
 }
 
 bool msg1230_equals(const rtcm_msg_1230 *lhs, const rtcm_msg_1230 *rhs)

--- a/c/test/rtcm_decoder_tests.h
+++ b/c/test/rtcm_decoder_tests.h
@@ -26,6 +26,7 @@ static void test_rtcm_1008(void);
 static void test_rtcm_1010(void);
 static void test_rtcm_1012(void);
 static void test_rtcm_1230(void);
+static void test_rtcm_1033(void);
 
 bool msgobs_equals(const rtcm_obs_message *msg_in,
                    const rtcm_obs_message *msg_out);
@@ -35,6 +36,7 @@ bool msg1005_equals(const rtcm_msg_1005 *lhs, const rtcm_msg_1005 *rhs);
 bool msg1006_equals(const rtcm_msg_1006 *lhs, const rtcm_msg_1006 *rhs);
 bool msg1007_equals(const rtcm_msg_1007 *lhs, const rtcm_msg_1007 *rhs);
 bool msg1008_equals(const rtcm_msg_1008 *lhs, const rtcm_msg_1008 *rhs);
+bool msg1033_equals(const rtcm_msg_1033 *lhs, const rtcm_msg_1033 *rhs);
 bool msg1230_equals(const rtcm_msg_1230 *lhs, const rtcm_msg_1230 *rhs);
 
 #endif // PIKSI_BUILDROOT_RTCM_DECODER_TESTS_H

--- a/c/test/rtcm_encoder.c
+++ b/c/test/rtcm_encoder.c
@@ -630,6 +630,56 @@ uint16_t rtcm3_encode_1012(const rtcm_obs_message *msg_1012, uint8_t *buff)
   return (bit + 7) / 8;
 }
 
+uint16_t rtcm3_encode_1033(const rtcm_msg_1033 *msg_1033, uint8_t *buff)
+{
+  uint16_t bit = 0;
+  setbitu(buff, bit, 12, 1033);
+  bit += 12;
+
+  setbitu(buff, bit, 12, msg_1033->stn_id);
+  bit += 12;
+
+  setbitu(buff, bit, 8, msg_1033->antenna_desc_counter);
+  bit += 8;
+  for (uint8_t i = 0; i < msg_1033->antenna_desc_counter; ++i) {
+    setbitu(buff, bit, 8, msg_1033->antenna_descriptor[i]);
+    bit += 8;
+  }
+
+  setbits(buff, bit, 8, msg_1033->antenna_setup_ID);
+  bit += 8;
+
+  setbitu(buff, bit, 8, msg_1033->antenna_serial_num_counter);
+  bit += 8;
+  for (uint8_t i = 0; i < 5; ++i) {
+    setbitu(buff, bit, 8, msg_1033->antenna_serial_num[i]);
+    bit += 8;
+  }
+
+  setbitu(buff, bit, 8, msg_1033->rcv_descriptor_counter);
+  bit += 8;
+  for (uint8_t i = 0; i < 3; ++i) {
+    setbitu(buff, bit, 8, msg_1033->rcv_descriptor[i]);
+    bit += 8;
+  }
+
+  setbitu(buff, bit, 8, msg_1033->rcv_fw_counter);
+  bit += 8;
+  for (uint8_t i = 0; i < 3; ++i) {
+    setbitu(buff, bit, 8, msg_1033->rcv_fw_version[i]);
+    bit += 8;
+  }
+
+  setbitu(buff, bit, 8, msg_1033->rcv_serial_num_counter);
+  bit += 8;
+  for (uint8_t i = 0; i < 3; ++i) {
+    setbitu(buff, bit, 8, msg_1033->rcv_serial_num[i]);
+    bit += 8;
+  }
+  /* Round number of bits up to nearest whole byte. */
+  return (bit + 7) / 8;
+}
+
 uint16_t rtcm3_encode_1230(const rtcm_msg_1230 *msg_1230, uint8_t *buff)
 {
   uint16_t bit = 0;

--- a/c/test/rtcm_encoder.h
+++ b/c/test/rtcm_encoder.h
@@ -37,6 +37,7 @@ uint16_t rtcm3_encode_1007(const rtcm_msg_1007 *msg_1007, uint8_t *buff);
 uint16_t rtcm3_encode_1008(const rtcm_msg_1008 *msg_1008, uint8_t *buff);
 uint16_t rtcm3_encode_1010(const rtcm_obs_message *msg_1010, uint8_t *buff);
 uint16_t rtcm3_encode_1012(const rtcm_obs_message *msg_1012, uint8_t *buff);
+uint16_t rtcm3_encode_1033(const rtcm_msg_1033 *msg_1033, uint8_t *buff);
 uint16_t rtcm3_encode_1230(const rtcm_msg_1230 *msg_1230, uint8_t *buff);
 
 #endif //LIBRTCM_RTCM_ENCODER_H


### PR DESCRIPTION
Add decoding for the 1033 message support. This is only needed on the RTCM decoder as skylark should never need to translate this message and should instead send the RTCM1230 message directly.

@mfine 