### PR TITLE
Signed Magnitudes

### DIFF
--- a/haskell/src/Data/RTCM3/Ephemerides.hs
+++ b/haskell/src/Data/RTCM3/Ephemerides.hs
@@ -328,21 +328,21 @@ instance BinaryBit GlonassEphemeris where
     _glonassEphemeris_bn_msb             <- B.getBool
     _glonassEphemeris_p2                 <- B.getBool
     _glonassEphemeris_tb                 <- B.getWord8 7
-    _glonassEphemeris_xndot              <- getInt32be 24
-    _glonassEphemeris_xn                 <- getInt32be 27
-    _glonassEphemeris_xndotdot           <- getInt8 5
-    _glonassEphemeris_yndot              <- getInt32be 24
-    _glonassEphemeris_yn                 <- getInt32be 27
-    _glonassEphemeris_yndotdot           <- getInt8 5
-    _glonassEphemeris_zndot              <- getInt32be 24
-    _glonassEphemeris_zn                 <- getInt32be 27
-    _glonassEphemeris_zndotdot           <- getInt8 5
+    _glonassEphemeris_xndot              <- getSInt32be 24
+    _glonassEphemeris_xn                 <- getSInt32be 27
+    _glonassEphemeris_xndotdot           <- getSInt8 5
+    _glonassEphemeris_yndot              <- getSInt32be 24
+    _glonassEphemeris_yn                 <- getSInt32be 27
+    _glonassEphemeris_yndotdot           <- getSInt8 5
+    _glonassEphemeris_zndot              <- getSInt32be 24
+    _glonassEphemeris_zn                 <- getSInt32be 27
+    _glonassEphemeris_zndotdot           <- getSInt8 5
     _glonassEphemeris_p3                 <- B.getBool
-    _glonassEphemeris_gammaN             <- getInt16be 11
+    _glonassEphemeris_gammaN             <- getSInt16be 11
     _glonassEphemeris_mp                 <- B.getWord8 2
     _glonassEphemeris_mi3                <- B.getBool
-    _glonassEphemeris_tauN               <- getInt32be 22
-    _glonassEphemeris_mdeltatau          <- getInt8 5
+    _glonassEphemeris_tauN               <- getSInt32be 22
+    _glonassEphemeris_mdeltatau          <- getSInt8 5
     _glonassEphemeris_en                 <- B.getWord8 5
     _glonassEphemeris_mp4                <- B.getBool
     _glonassEphemeris_mft                <- B.getWord8 4
@@ -350,9 +350,9 @@ instance BinaryBit GlonassEphemeris where
     _glonassEphemeris_mM                 <- B.getWord8 2
     _glonassEphemeris_additional         <- B.getBool
     _glonassEphemeris_nA                 <- B.getWord16be 11
-    _glonassEphemeris_tauC               <- getInt32be 32
+    _glonassEphemeris_tauC               <- getSInt32be 32
     _glonassEphemeris_mn4                <- B.getWord8 5
-    _glonassEphemeris_mTauGps            <- getInt32be 22
+    _glonassEphemeris_mTauGps            <- getSInt32be 22
     _glonassEphemeris_mln5               <- B.getBool
     _glonassEphemeris_reserved           <- B.getWord8 7
     pure GlonassEphemeris{..}
@@ -365,21 +365,21 @@ instance BinaryBit GlonassEphemeris where
     B.putBool        _glonassEphemeris_bn_msb
     B.putBool        _glonassEphemeris_p2
     B.putWord8    7  _glonassEphemeris_tb
-    putInt32be    24 _glonassEphemeris_xndot
-    putInt32be    27 _glonassEphemeris_xn
-    putInt8       5  _glonassEphemeris_xndotdot
-    putInt32be    24 _glonassEphemeris_yndot
-    putInt32be    27 _glonassEphemeris_yn
-    putInt8       5  _glonassEphemeris_yndotdot
-    putInt32be    24 _glonassEphemeris_zndot
-    putInt32be    27 _glonassEphemeris_zn
-    putInt8       5  _glonassEphemeris_zndotdot
+    putSInt32be   24 _glonassEphemeris_xndot
+    putSInt32be   27 _glonassEphemeris_xn
+    putSInt8      5  _glonassEphemeris_xndotdot
+    putSInt32be   24 _glonassEphemeris_yndot
+    putSInt32be   27 _glonassEphemeris_yn
+    putSInt8      5  _glonassEphemeris_yndotdot
+    putSInt32be   24 _glonassEphemeris_zndot
+    putSInt32be   27 _glonassEphemeris_zn
+    putSInt8      5  _glonassEphemeris_zndotdot
     B.putBool        _glonassEphemeris_p3
-    putInt16be    11 _glonassEphemeris_gammaN
+    putSInt16be   11 _glonassEphemeris_gammaN
     B.putWord8    2  _glonassEphemeris_mp
     B.putBool        _glonassEphemeris_mi3
-    putInt32be    22 _glonassEphemeris_tauN
-    putInt8       5  _glonassEphemeris_mdeltatau
+    putSInt32be   22 _glonassEphemeris_tauN
+    putSInt8      5  _glonassEphemeris_mdeltatau
     B.putWord8    5  _glonassEphemeris_en
     B.putBool        _glonassEphemeris_mp4
     B.putWord8    4  _glonassEphemeris_mft
@@ -387,9 +387,9 @@ instance BinaryBit GlonassEphemeris where
     B.putWord8    2  _glonassEphemeris_mM
     B.putBool        _glonassEphemeris_additional
     B.putWord16be 11 _glonassEphemeris_nA
-    putInt32be    32 _glonassEphemeris_tauC
+    putSInt32be   32 _glonassEphemeris_tauC
     B.putWord8    5  _glonassEphemeris_mn4
-    putInt32be    22 _glonassEphemeris_mTauGps
+    putSInt32be   22 _glonassEphemeris_mTauGps
     B.putBool        _glonassEphemeris_mln5
     B.putWord8    7  _glonassEphemeris_reserved
 

--- a/haskell/src/Data/RTCM3/Extras.hs
+++ b/haskell/src/Data/RTCM3/Extras.hs
@@ -19,6 +19,14 @@ module Data.RTCM3.Extras
   , putInt16be
   , putInt32be
   , putInt64be
+  , getSInt8
+  , getSInt16be
+  , getSInt32be
+  , getSInt64be
+  , putSInt8
+  , putSInt16be
+  , putSInt32be
+  , putSInt64be
   , getWord24be
   , putWord24be
   ) where
@@ -66,6 +74,46 @@ putInt32be n = B.putWord32be n . fromIntegral
 
 putInt64be :: Int -> Int64 -> B.BitPut ()
 putInt64be n = B.putWord64be n . fromIntegral
+
+getSInt8 :: Int -> B.BitGet Int8
+getSInt8 n = do
+  signed <- B.getBool
+  bool id negate signed . fromIntegral <$> B.getWord8 (n - 1)
+
+getSInt16be :: Int -> B.BitGet Int16
+getSInt16be n = do
+  signed <- B.getBool
+  bool id negate signed . fromIntegral <$> B.getWord16be (n - 1)
+
+getSInt32be :: Int -> B.BitGet Int32
+getSInt32be n = do
+  signed <- B.getBool
+  bool id negate signed . fromIntegral <$> B.getWord32be (n - 1)
+
+getSInt64be :: Int -> B.BitGet Int64
+getSInt64be n = do
+  signed <- B.getBool
+  bool id negate signed . fromIntegral <$> B.getWord64be (n - 1)
+
+putSInt8 :: Int -> Int8 -> B.BitPut ()
+putSInt8 n v = do
+  B.putBool $ v < 0
+  B.putWord8 (n - 1) $ fromIntegral (abs v)
+
+putSInt16be :: Int -> Int16 -> B.BitPut ()
+putSInt16be n v = do
+  B.putBool $ v < 0
+  B.putWord16be (n - 1) $ fromIntegral (abs v)
+
+putSInt32be :: Int -> Int32 -> B.BitPut ()
+putSInt32be n v = do
+  B.putBool $ v < 0
+  B.putWord32be (n - 1) $ fromIntegral (abs v)
+
+putSInt64be :: Int -> Int64 -> B.BitPut ()
+putSInt64be n v = do
+  B.putBool $ v < 0
+  B.putWord64be (n - 1) $ fromIntegral (abs v)
 
 getWord24be :: Get Word24
 getWord24be = do

--- a/haskell/test/Test/Data/RTCM3/Extras.hs
+++ b/haskell/test/Test/Data/RTCM3/Extras.hs
@@ -84,6 +84,26 @@ testInt64be =
   testProperty "Roundtrip Int64be" $ \(TestInt n i) ->
     decodeBits (getInt64be n) (encodeBits (putInt64be n i)) == (i :: Int64)
 
+testSInt8 :: TestTree
+testSInt8 =
+  testProperty "Roundtrip SInt8" $ \(TestInt n i) ->
+    decodeBits (getSInt8 n) (encodeBits (putSInt8 n i)) == (i :: Int8)
+
+testSInt16be :: TestTree
+testSInt16be =
+  testProperty "Roundtrip SInt16" $ \(TestInt n i) ->
+    decodeBits (getSInt16be n) (encodeBits (putSInt16be n i)) == (i :: Int16)
+
+testSInt32be :: TestTree
+testSInt32be =
+  testProperty "Roundtrip SInt32" $ \(TestInt n i) ->
+    decodeBits (getSInt32be n) (encodeBits (putSInt32be n i)) == (i :: Int32)
+
+testSInt64be :: TestTree
+testSInt64be =
+  testProperty "Roundtrip SInt64be" $ \(TestInt n i) ->
+    decodeBits (getSInt64be n) (encodeBits (putSInt64be n i)) == (i :: Int64)
+
 testWord24be :: TestTree
 testWord24be =
   testProperty "Roundtrip Word24be" $ \i ->
@@ -96,5 +116,9 @@ tests =
     , testInt16be
     , testInt32be
     , testInt64be
+    , testSInt8
+    , testSInt16be
+    , testSInt32be
+    , testSInt64be
     , testWord24be
     ]


### PR DESCRIPTION
Glonass ephemeris uses signed integers as defined by:

```
Sign-magnitude representation records the number's sign and magnitude. MSb is 0 for positive numbers and 1 for negative numbers. The rest of the bits are the number's magnitude. For example, for 8-bit words, the representations of the numbers "-5" and "+5" in a binary form are 10000101 and 00000101, respectively. Negative zero is not used.
```

Switch glonass over to these representations.

/cc @benjamin0 