### PR TITLE
MAP-273 - MSM Support in Haskell RTCM

### DIFF
--- a/haskell/rtcm.cabal
+++ b/haskell/rtcm.cabal
@@ -1,5 +1,5 @@
 name:                  rtcm
-version:               0.2.15
+version:               0.2.16
 synopsis:              Haskell bindings for RTCM.
 homepage:              http://github.com/swift-nav/librtcm
 license:               BSD3
@@ -26,6 +26,7 @@ library
                      , Data.RTCM3.Antennas
                      , Data.RTCM3.Ephemerides
                      , Data.RTCM3.Internal
+                     , Data.RTCM3.MSM
                      , Data.RTCM3.Observations
                      , Data.RTCM3.SSR
                      , Data.RTCM3.System
@@ -83,6 +84,7 @@ test-suite test
                      , Test.Data.RTCM3.Antennas
                      , Test.Data.RTCM3.Ephemerides
                      , Test.Data.RTCM3.Extras
+                     , Test.Data.RTCM3.MSM
                      , Test.Data.RTCM3.Observations
                      , Test.Data.RTCM3.SSR
                      , Test.Data.RTCM3.System

--- a/haskell/rtcm.cabal.m4
+++ b/haskell/rtcm.cabal.m4
@@ -26,6 +26,7 @@ library
                      , Data.RTCM3.Antennas
                      , Data.RTCM3.Ephemerides
                      , Data.RTCM3.Internal
+                     , Data.RTCM3.MSM
                      , Data.RTCM3.Observations
                      , Data.RTCM3.SSR
                      , Data.RTCM3.System
@@ -83,6 +84,7 @@ test-suite test
                      , Test.Data.RTCM3.Antennas
                      , Test.Data.RTCM3.Ephemerides
                      , Test.Data.RTCM3.Extras
+                     , Test.Data.RTCM3.MSM
                      , Test.Data.RTCM3.Observations
                      , Test.Data.RTCM3.SSR
                      , Test.Data.RTCM3.System

--- a/haskell/src/Data/RTCM3.hs
+++ b/haskell/src/Data/RTCM3.hs
@@ -26,6 +26,7 @@ import Data.Binary
 import Data.ByteString.Lazy
 import Data.RTCM3.Antennas     as Export
 import Data.RTCM3.Ephemerides  as Export
+import Data.RTCM3.MSM          as Export
 import Data.RTCM3.Observations as Export
 import Data.RTCM3.SSR          as Export
 import Data.RTCM3.System       as Export
@@ -61,6 +62,7 @@ data RTCM3Msg =
    | RTCM3Msg1064    Msg1064 Msg
    | RTCM3Msg1065    Msg1065 Msg
    | RTCM3Msg1066    Msg1066 Msg
+   | RTCM3Msg1074    Msg1074 Msg
    | RTCM3Msg1230    Msg1230 Msg
    | RTCM3Msg1265    Msg1265 Msg
    | RTCM3Msg1266    Msg1266 Msg
@@ -104,6 +106,7 @@ instance Binary RTCM3Msg where
           | num == msg1064 = RTCM3Msg1064 (decode $ fromStrict $ unBytes _msgRTCM3Payload) m
           | num == msg1065 = RTCM3Msg1065 (decode $ fromStrict $ unBytes _msgRTCM3Payload) m
           | num == msg1066 = RTCM3Msg1066 (decode $ fromStrict $ unBytes _msgRTCM3Payload) m
+          | num == msg1074 = RTCM3Msg1074 (decode $ fromStrict $ unBytes _msgRTCM3Payload) m
           | num == msg1230 = RTCM3Msg1230 (decode $ fromStrict $ unBytes _msgRTCM3Payload) m
           | num == msg1265 = RTCM3Msg1265 (decode $ fromStrict $ unBytes _msgRTCM3Payload) m
           | num == msg1266 = RTCM3Msg1266 (decode $ fromStrict $ unBytes _msgRTCM3Payload) m
@@ -139,6 +142,7 @@ instance Binary RTCM3Msg where
       encoder (RTCM3Msg1064    _n m) = put m
       encoder (RTCM3Msg1065    _n m) = put m
       encoder (RTCM3Msg1066    _n m) = put m
+      encoder (RTCM3Msg1074    _n m) = put m
       encoder (RTCM3Msg1230    _n m) = put m
       encoder (RTCM3Msg1265    _n m) = put m
       encoder (RTCM3Msg1266    _n m) = put m
@@ -172,6 +176,7 @@ instance HasMsg RTCM3Msg where
   msg f (RTCM3Msg1064    n m) = RTCM3Msg1064    n <$> f m
   msg f (RTCM3Msg1065    n m) = RTCM3Msg1065    n <$> f m
   msg f (RTCM3Msg1066    n m) = RTCM3Msg1066    n <$> f m
+  msg f (RTCM3Msg1074    n m) = RTCM3Msg1074    n <$> f m
   msg f (RTCM3Msg1230    n m) = RTCM3Msg1230    n <$> f m
   msg f (RTCM3Msg1265    n m) = RTCM3Msg1265    n <$> f m
   msg f (RTCM3Msg1266    n m) = RTCM3Msg1266    n <$> f m
@@ -211,6 +216,7 @@ instance ToJSON RTCM3Msg where
   toJSON (RTCM3Msg1064    n m) = toJSON n <<>> toJSON m
   toJSON (RTCM3Msg1065    n m) = toJSON n <<>> toJSON m
   toJSON (RTCM3Msg1066    n m) = toJSON n <<>> toJSON m
+  toJSON (RTCM3Msg1074    n m) = toJSON n <<>> toJSON m
   toJSON (RTCM3Msg1230    n m) = toJSON n <<>> toJSON m
   toJSON (RTCM3Msg1265    n m) = toJSON n <<>> toJSON m
   toJSON (RTCM3Msg1266    n m) = toJSON n <<>> toJSON m
@@ -248,6 +254,7 @@ instance FromJSON RTCM3Msg where
         | num == msg1064 = RTCM3Msg1064 <$> pure (decode $ fromStrict $ unBytes payload) <*> parseJSON obj
         | num == msg1065 = RTCM3Msg1065 <$> pure (decode $ fromStrict $ unBytes payload) <*> parseJSON obj
         | num == msg1066 = RTCM3Msg1066 <$> pure (decode $ fromStrict $ unBytes payload) <*> parseJSON obj
+        | num == msg1074 = RTCM3Msg1074 <$> pure (decode $ fromStrict $ unBytes payload) <*> parseJSON obj
         | num == msg1230 = RTCM3Msg1230 <$> pure (decode $ fromStrict $ unBytes payload) <*> parseJSON obj
         | num == msg1265 = RTCM3Msg1265 <$> pure (decode $ fromStrict $ unBytes payload) <*> parseJSON obj
         | otherwise = RTCM3MsgUnknown <$> pure num <*> parseJSON obj

--- a/haskell/src/Data/RTCM3.hs
+++ b/haskell/src/Data/RTCM3.hs
@@ -63,6 +63,29 @@ data RTCM3Msg =
    | RTCM3Msg1065    Msg1065 Msg
    | RTCM3Msg1066    Msg1066 Msg
    | RTCM3Msg1074    Msg1074 Msg
+   | RTCM3Msg1075    Msg1075 Msg
+   | RTCM3Msg1076    Msg1076 Msg
+   | RTCM3Msg1077    Msg1077 Msg
+   | RTCM3Msg1084    Msg1084 Msg
+   | RTCM3Msg1085    Msg1085 Msg
+   | RTCM3Msg1086    Msg1086 Msg
+   | RTCM3Msg1087    Msg1087 Msg
+   | RTCM3Msg1094    Msg1094 Msg
+   | RTCM3Msg1095    Msg1095 Msg
+   | RTCM3Msg1096    Msg1096 Msg
+   | RTCM3Msg1097    Msg1097 Msg
+   | RTCM3Msg1104    Msg1104 Msg
+   | RTCM3Msg1105    Msg1105 Msg
+   | RTCM3Msg1106    Msg1106 Msg
+   | RTCM3Msg1107    Msg1107 Msg
+   | RTCM3Msg1114    Msg1114 Msg
+   | RTCM3Msg1115    Msg1115 Msg
+   | RTCM3Msg1116    Msg1116 Msg
+   | RTCM3Msg1117    Msg1117 Msg
+   | RTCM3Msg1124    Msg1124 Msg
+   | RTCM3Msg1125    Msg1125 Msg
+   | RTCM3Msg1126    Msg1126 Msg
+   | RTCM3Msg1127    Msg1127 Msg
    | RTCM3Msg1230    Msg1230 Msg
    | RTCM3Msg1265    Msg1265 Msg
    | RTCM3Msg1266    Msg1266 Msg
@@ -107,6 +130,29 @@ instance Binary RTCM3Msg where
           | num == msg1065 = RTCM3Msg1065 (decode $ fromStrict $ unBytes _msgRTCM3Payload) m
           | num == msg1066 = RTCM3Msg1066 (decode $ fromStrict $ unBytes _msgRTCM3Payload) m
           | num == msg1074 = RTCM3Msg1074 (decode $ fromStrict $ unBytes _msgRTCM3Payload) m
+          | num == msg1075 = RTCM3Msg1075 (decode $ fromStrict $ unBytes _msgRTCM3Payload) m
+          | num == msg1076 = RTCM3Msg1076 (decode $ fromStrict $ unBytes _msgRTCM3Payload) m
+          | num == msg1077 = RTCM3Msg1077 (decode $ fromStrict $ unBytes _msgRTCM3Payload) m
+          | num == msg1084 = RTCM3Msg1084 (decode $ fromStrict $ unBytes _msgRTCM3Payload) m
+          | num == msg1085 = RTCM3Msg1085 (decode $ fromStrict $ unBytes _msgRTCM3Payload) m
+          | num == msg1086 = RTCM3Msg1086 (decode $ fromStrict $ unBytes _msgRTCM3Payload) m
+          | num == msg1087 = RTCM3Msg1087 (decode $ fromStrict $ unBytes _msgRTCM3Payload) m
+          | num == msg1094 = RTCM3Msg1094 (decode $ fromStrict $ unBytes _msgRTCM3Payload) m
+          | num == msg1095 = RTCM3Msg1095 (decode $ fromStrict $ unBytes _msgRTCM3Payload) m
+          | num == msg1096 = RTCM3Msg1096 (decode $ fromStrict $ unBytes _msgRTCM3Payload) m
+          | num == msg1097 = RTCM3Msg1097 (decode $ fromStrict $ unBytes _msgRTCM3Payload) m
+          | num == msg1104 = RTCM3Msg1104 (decode $ fromStrict $ unBytes _msgRTCM3Payload) m
+          | num == msg1105 = RTCM3Msg1105 (decode $ fromStrict $ unBytes _msgRTCM3Payload) m
+          | num == msg1106 = RTCM3Msg1106 (decode $ fromStrict $ unBytes _msgRTCM3Payload) m
+          | num == msg1107 = RTCM3Msg1107 (decode $ fromStrict $ unBytes _msgRTCM3Payload) m
+          | num == msg1114 = RTCM3Msg1114 (decode $ fromStrict $ unBytes _msgRTCM3Payload) m
+          | num == msg1115 = RTCM3Msg1125 (decode $ fromStrict $ unBytes _msgRTCM3Payload) m
+          | num == msg1116 = RTCM3Msg1116 (decode $ fromStrict $ unBytes _msgRTCM3Payload) m
+          | num == msg1117 = RTCM3Msg1117 (decode $ fromStrict $ unBytes _msgRTCM3Payload) m
+          | num == msg1124 = RTCM3Msg1124 (decode $ fromStrict $ unBytes _msgRTCM3Payload) m
+          | num == msg1125 = RTCM3Msg1125 (decode $ fromStrict $ unBytes _msgRTCM3Payload) m
+          | num == msg1126 = RTCM3Msg1126 (decode $ fromStrict $ unBytes _msgRTCM3Payload) m
+          | num == msg1127 = RTCM3Msg1127 (decode $ fromStrict $ unBytes _msgRTCM3Payload) m
           | num == msg1230 = RTCM3Msg1230 (decode $ fromStrict $ unBytes _msgRTCM3Payload) m
           | num == msg1265 = RTCM3Msg1265 (decode $ fromStrict $ unBytes _msgRTCM3Payload) m
           | num == msg1266 = RTCM3Msg1266 (decode $ fromStrict $ unBytes _msgRTCM3Payload) m
@@ -143,6 +189,29 @@ instance Binary RTCM3Msg where
       encoder (RTCM3Msg1065    _n m) = put m
       encoder (RTCM3Msg1066    _n m) = put m
       encoder (RTCM3Msg1074    _n m) = put m
+      encoder (RTCM3Msg1075    _n m) = put m
+      encoder (RTCM3Msg1076    _n m) = put m
+      encoder (RTCM3Msg1077    _n m) = put m
+      encoder (RTCM3Msg1084    _n m) = put m
+      encoder (RTCM3Msg1085    _n m) = put m
+      encoder (RTCM3Msg1086    _n m) = put m
+      encoder (RTCM3Msg1087    _n m) = put m
+      encoder (RTCM3Msg1094    _n m) = put m
+      encoder (RTCM3Msg1095    _n m) = put m
+      encoder (RTCM3Msg1096    _n m) = put m
+      encoder (RTCM3Msg1097    _n m) = put m
+      encoder (RTCM3Msg1104    _n m) = put m
+      encoder (RTCM3Msg1105    _n m) = put m
+      encoder (RTCM3Msg1106    _n m) = put m
+      encoder (RTCM3Msg1107    _n m) = put m
+      encoder (RTCM3Msg1114    _n m) = put m
+      encoder (RTCM3Msg1115    _n m) = put m
+      encoder (RTCM3Msg1116    _n m) = put m
+      encoder (RTCM3Msg1117    _n m) = put m
+      encoder (RTCM3Msg1124    _n m) = put m
+      encoder (RTCM3Msg1125    _n m) = put m
+      encoder (RTCM3Msg1126    _n m) = put m
+      encoder (RTCM3Msg1127    _n m) = put m
       encoder (RTCM3Msg1230    _n m) = put m
       encoder (RTCM3Msg1265    _n m) = put m
       encoder (RTCM3Msg1266    _n m) = put m
@@ -177,6 +246,29 @@ instance HasMsg RTCM3Msg where
   msg f (RTCM3Msg1065    n m) = RTCM3Msg1065    n <$> f m
   msg f (RTCM3Msg1066    n m) = RTCM3Msg1066    n <$> f m
   msg f (RTCM3Msg1074    n m) = RTCM3Msg1074    n <$> f m
+  msg f (RTCM3Msg1075    n m) = RTCM3Msg1075    n <$> f m
+  msg f (RTCM3Msg1076    n m) = RTCM3Msg1076    n <$> f m
+  msg f (RTCM3Msg1077    n m) = RTCM3Msg1077    n <$> f m
+  msg f (RTCM3Msg1084    n m) = RTCM3Msg1084    n <$> f m
+  msg f (RTCM3Msg1085    n m) = RTCM3Msg1085    n <$> f m
+  msg f (RTCM3Msg1086    n m) = RTCM3Msg1086    n <$> f m
+  msg f (RTCM3Msg1087    n m) = RTCM3Msg1087    n <$> f m
+  msg f (RTCM3Msg1094    n m) = RTCM3Msg1094    n <$> f m
+  msg f (RTCM3Msg1095    n m) = RTCM3Msg1095    n <$> f m
+  msg f (RTCM3Msg1096    n m) = RTCM3Msg1096    n <$> f m
+  msg f (RTCM3Msg1097    n m) = RTCM3Msg1097    n <$> f m
+  msg f (RTCM3Msg1104    n m) = RTCM3Msg1104    n <$> f m
+  msg f (RTCM3Msg1105    n m) = RTCM3Msg1105    n <$> f m
+  msg f (RTCM3Msg1106    n m) = RTCM3Msg1106    n <$> f m
+  msg f (RTCM3Msg1107    n m) = RTCM3Msg1107    n <$> f m
+  msg f (RTCM3Msg1114    n m) = RTCM3Msg1114    n <$> f m
+  msg f (RTCM3Msg1115    n m) = RTCM3Msg1115    n <$> f m
+  msg f (RTCM3Msg1116    n m) = RTCM3Msg1116    n <$> f m
+  msg f (RTCM3Msg1117    n m) = RTCM3Msg1117    n <$> f m
+  msg f (RTCM3Msg1124    n m) = RTCM3Msg1124    n <$> f m
+  msg f (RTCM3Msg1125    n m) = RTCM3Msg1125    n <$> f m
+  msg f (RTCM3Msg1126    n m) = RTCM3Msg1126    n <$> f m
+  msg f (RTCM3Msg1127    n m) = RTCM3Msg1127    n <$> f m
   msg f (RTCM3Msg1230    n m) = RTCM3Msg1230    n <$> f m
   msg f (RTCM3Msg1265    n m) = RTCM3Msg1265    n <$> f m
   msg f (RTCM3Msg1266    n m) = RTCM3Msg1266    n <$> f m
@@ -217,6 +309,29 @@ instance ToJSON RTCM3Msg where
   toJSON (RTCM3Msg1065    n m) = toJSON n <<>> toJSON m
   toJSON (RTCM3Msg1066    n m) = toJSON n <<>> toJSON m
   toJSON (RTCM3Msg1074    n m) = toJSON n <<>> toJSON m
+  toJSON (RTCM3Msg1075    n m) = toJSON n <<>> toJSON m
+  toJSON (RTCM3Msg1076    n m) = toJSON n <<>> toJSON m
+  toJSON (RTCM3Msg1077    n m) = toJSON n <<>> toJSON m
+  toJSON (RTCM3Msg1084    n m) = toJSON n <<>> toJSON m
+  toJSON (RTCM3Msg1085    n m) = toJSON n <<>> toJSON m
+  toJSON (RTCM3Msg1086    n m) = toJSON n <<>> toJSON m
+  toJSON (RTCM3Msg1087    n m) = toJSON n <<>> toJSON m
+  toJSON (RTCM3Msg1094    n m) = toJSON n <<>> toJSON m
+  toJSON (RTCM3Msg1095    n m) = toJSON n <<>> toJSON m
+  toJSON (RTCM3Msg1096    n m) = toJSON n <<>> toJSON m
+  toJSON (RTCM3Msg1097    n m) = toJSON n <<>> toJSON m
+  toJSON (RTCM3Msg1104    n m) = toJSON n <<>> toJSON m
+  toJSON (RTCM3Msg1105    n m) = toJSON n <<>> toJSON m
+  toJSON (RTCM3Msg1106    n m) = toJSON n <<>> toJSON m
+  toJSON (RTCM3Msg1107    n m) = toJSON n <<>> toJSON m
+  toJSON (RTCM3Msg1114    n m) = toJSON n <<>> toJSON m
+  toJSON (RTCM3Msg1115    n m) = toJSON n <<>> toJSON m
+  toJSON (RTCM3Msg1116    n m) = toJSON n <<>> toJSON m
+  toJSON (RTCM3Msg1117    n m) = toJSON n <<>> toJSON m
+  toJSON (RTCM3Msg1124    n m) = toJSON n <<>> toJSON m
+  toJSON (RTCM3Msg1125    n m) = toJSON n <<>> toJSON m
+  toJSON (RTCM3Msg1126    n m) = toJSON n <<>> toJSON m
+  toJSON (RTCM3Msg1127    n m) = toJSON n <<>> toJSON m
   toJSON (RTCM3Msg1230    n m) = toJSON n <<>> toJSON m
   toJSON (RTCM3Msg1265    n m) = toJSON n <<>> toJSON m
   toJSON (RTCM3Msg1266    n m) = toJSON n <<>> toJSON m

--- a/haskell/src/Data/RTCM3/MSM.hs
+++ b/haskell/src/Data/RTCM3/MSM.hs
@@ -103,9 +103,9 @@ instance BinaryBit MsmHeader where
 --
 -- MSM46 satellite data.
 data Msm46SatelliteData = Msm46SatelliteData
-  { _msm46SatelliteData_roughRanges       :: [Word8]
+  { _msm46SatelliteData_ranges       :: [Word8]
     -- ^ The number of integer milliseconds in GNSS Satellite rough ranges.
-  , _msm46SatelliteData_roughRangesModulo :: [Word16]
+  , _msm46SatelliteData_rangesModulo :: [Word16]
     -- ^ GNSS Satellite rough ranges modulo 1 millisecond.
   } deriving ( Show, Read, Eq )
 
@@ -116,28 +116,28 @@ $(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msm46SatelliteData
 --
 getBitsMsm46SatelliteData :: Int -> B.BitGet Msm46SatelliteData
 getBitsMsm46SatelliteData n = do
-  _msm46SatelliteData_roughRanges       <- replicateM n $ B.getWord8 8
-  _msm46SatelliteData_roughRangesModulo <- replicateM n $ B.getWord16be 10
+  _msm46SatelliteData_ranges       <- replicateM n $ B.getWord8 8
+  _msm46SatelliteData_rangesModulo <- replicateM n $ B.getWord16be 10
   pure Msm46SatelliteData {..}
 
 -- | Put Bits for Msm46SatelliteData.
 --
 putBitsMsm46SatelliteData :: Msm46SatelliteData -> B.BitPut ()
 putBitsMsm46SatelliteData Msm46SatelliteData {..} = do
-  forM_ _msm46SatelliteData_roughRanges $ B.putWord8 8
-  forM_ _msm46SatelliteData_roughRangesModulo $ B.putWord16be 10
+  forM_ _msm46SatelliteData_ranges $ B.putWord8 8
+  forM_ _msm46SatelliteData_rangesModulo $ B.putWord16be 10
 
 -- | Msm57SatelliteData
 --
 -- MSM57 satellite data.
 data Msm57SatelliteData = Msm57SatelliteData
-  { _msm57SatelliteData_roughRanges          :: [Word8]
+  { _msm57SatelliteData_ranges          :: [Word8]
     -- ^ The number of integer milliseconds in GNSS Satellite rough ranges.
-  , _msm57SatelliteData_extendeds            :: [Word8]
+  , _msm57SatelliteData_extendeds       :: [Word8]
     -- ^ Extended satellite information.
-  , _msm57SatelliteData_roughRangesModulo    :: [Word16]
+  , _msm57SatelliteData_rangesModulo    :: [Word16]
     -- ^ GNSS Satellite rough ranges modulo 1 millisecond.
-  , _msm57SatelliteData_roughPhaseRangeRates :: [Word16]
+  , _msm57SatelliteData_phaseRangeRates :: [Word16]
     -- ^ GNSS Satellite rough PhaseRangeRates.
   } deriving ( Show, Read, Eq )
 
@@ -148,24 +148,24 @@ $(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msm57SatelliteData
 --
 getBitsMsm57SatelliteData :: Int -> B.BitGet Msm57SatelliteData
 getBitsMsm57SatelliteData n = do
-  _msm57SatelliteData_roughRanges          <- replicateM n $ B.getWord8 8
-  _msm57SatelliteData_extendeds            <- replicateM n $ B.getWord8 4
-  _msm57SatelliteData_roughRangesModulo    <- replicateM n $ B.getWord16be 10
-  _msm57SatelliteData_roughPhaseRangeRates <- replicateM n $ B.getWord16be 14
+  _msm57SatelliteData_ranges          <- replicateM n $ B.getWord8 8
+  _msm57SatelliteData_extendeds       <- replicateM n $ B.getWord8 4
+  _msm57SatelliteData_rangesModulo    <- replicateM n $ B.getWord16be 10
+  _msm57SatelliteData_phaseRangeRates <- replicateM n $ B.getWord16be 14
   pure Msm57SatelliteData {..}
 
 -- | Put Bits for Msm4SatelliteData.
 --
 putBitsMsm57SatelliteData :: Msm57SatelliteData -> B.BitPut ()
 putBitsMsm57SatelliteData Msm57SatelliteData {..} = do
-  forM_ _msm57SatelliteData_roughRanges $ B.putWord8 8
+  forM_ _msm57SatelliteData_ranges $ B.putWord8 8
   forM_ _msm57SatelliteData_extendeds $ B.putWord8 4
-  forM_ _msm57SatelliteData_roughRangesModulo $ B.putWord16be 10
-  forM_ _msm57SatelliteData_roughPhaseRangeRates $ B.putWord16be 14
+  forM_ _msm57SatelliteData_rangesModulo $ B.putWord16be 10
+  forM_ _msm57SatelliteData_phaseRangeRates $ B.putWord16be 14
 
 -- | Msm4SignalData.
 --
--- MSM4 satellite data.
+-- MSM4 signal data.
 data Msm4SignalData = Msm4SignalData
   { _msm4SignalData_pseudoranges :: [Int16]
     -- ^ GNSS signal fine pseudoranges.
@@ -205,7 +205,7 @@ putBitsMsm4SignalData Msm4SignalData {..} = do
 
 -- | Msm5SignalData.
 --
--- MSM5 satellite data.
+-- MSM5 signal data.
 data Msm5SignalData = Msm5SignalData
   { _msm5SignalData_pseudoranges    :: [Int16]
     -- ^ GNSS signal fine pseudoranges.
@@ -249,7 +249,7 @@ putBitsMsm5SignalData Msm5SignalData {..} = do
 
 -- | Msm6SignalData.
 --
--- MSM6 satellite data.
+-- MSM6 signal data.
 data Msm6SignalData = Msm6SignalData
   { _msm6SignalData_pseudoranges :: [Int32]
     -- ^ GNSS signal fine pseudoranges.
@@ -289,7 +289,7 @@ putBitsMsm6SignalData Msm6SignalData {..} = do
 
 -- | Msm7SignalData.
 --
--- MSM7 satellite data.
+-- MSM7 signal data.
 data Msm7SignalData = Msm7SignalData
   { _msm7SignalData_pseudoranges    :: [Int32]
     -- ^ GNSS signal fine pseudoranges.
@@ -338,7 +338,7 @@ msg1074 = 1074
 --
 -- RTCMv3 message 1074.
 --
--- See RTCM spec and GLONASS signal specification for more information
+-- See RTCM spec and MSM signal specification for more information
 -- about these fields.
 data Msg1074 = Msg1074
   { _msg1074_header        :: MsmHeader
@@ -373,7 +373,7 @@ msg1075 = 1075
 --
 -- RTCMv3 message 1075.
 --
--- See RTCM spec and GLONASS signal specification for more information
+-- See RTCM spec and MSM signal specification for more information
 -- about these fields.
 data Msg1075 = Msg1075
   { _msg1075_header        :: MsmHeader
@@ -408,7 +408,7 @@ msg1076 = 1076
 --
 -- RTCMv3 message 1076.
 --
--- See RTCM spec and GLONASS signal specification for more information
+-- See RTCM spec and MSM signal specification for more information
 -- about these fields.
 data Msg1076 = Msg1076
   { _msg1076_header        :: MsmHeader
@@ -443,7 +443,7 @@ msg1077 = 1077
 --
 -- RTCMv3 message 1077.
 --
--- See RTCM spec and GLONASS signal specification for more information
+-- See RTCM spec and MSM signal specification for more information
 -- about these fields.
 data Msg1077 = Msg1077
   { _msg1077_header        :: MsmHeader
@@ -478,7 +478,7 @@ msg1084 = 1084
 --
 -- RTCMv3 message 1084.
 --
--- See RTCM spec and GLONASS signal specification for more information
+-- See RTCM spec and MSM signal specification for more information
 -- about these fields.
 data Msg1084 = Msg1084
   { _msg1084_header        :: MsmHeader
@@ -513,7 +513,7 @@ msg1085 = 1085
 --
 -- RTCMv3 message 1085.
 --
--- See RTCM spec and GLONASS signal specification for more information
+-- See RTCM spec and MSM signal specification for more information
 -- about these fields.
 data Msg1085 = Msg1085
   { _msg1085_header        :: MsmHeader
@@ -548,7 +548,7 @@ msg1086 = 1086
 --
 -- RTCMv3 message 1086.
 --
--- See RTCM spec and GLONASS signal specification for more information
+-- See RTCM spec and MSM signal specification for more information
 -- about these fields.
 data Msg1086 = Msg1086
   { _msg1086_header        :: MsmHeader
@@ -583,7 +583,7 @@ msg1087 = 1087
 --
 -- RTCMv3 message 1087.
 --
--- See RTCM spec and GLONASS signal specification for more information
+-- See RTCM spec and MSM signal specification for more information
 -- about these fields.
 data Msg1087 = Msg1087
   { _msg1087_header        :: MsmHeader
@@ -618,7 +618,7 @@ msg1094 = 1094
 --
 -- RTCMv3 message 1094.
 --
--- See RTCM spec and GLONASS signal specification for more information
+-- See RTCM spec and MSM signal specification for more information
 -- about these fields.
 data Msg1094 = Msg1094
   { _msg1094_header        :: MsmHeader
@@ -653,7 +653,7 @@ msg1095 = 1095
 --
 -- RTCMv3 message 1095.
 --
--- See RTCM spec and GLONASS signal specification for more information
+-- See RTCM spec and MSM signal specification for more information
 -- about these fields.
 data Msg1095 = Msg1095
   { _msg1095_header        :: MsmHeader
@@ -688,7 +688,7 @@ msg1096 = 1096
 --
 -- RTCMv3 message 1096.
 --
--- See RTCM spec and GLONASS signal specification for more information
+-- See RTCM spec and MSM signal specification for more information
 -- about these fields.
 data Msg1096 = Msg1096
   { _msg1096_header        :: MsmHeader
@@ -723,7 +723,7 @@ msg1097 = 1097
 --
 -- RTCMv3 message 1097.
 --
--- See RTCM spec and GLONASS signal specification for more information
+-- See RTCM spec and MSM signal specification for more information
 -- about these fields.
 data Msg1097 = Msg1097
   { _msg1097_header        :: MsmHeader
@@ -758,7 +758,7 @@ msg1104 = 1104
 --
 -- RTCMv3 message 1104.
 --
--- See RTCM spec and GLONASS signal specification for more information
+-- See RTCM spec and MSM signal specification for more information
 -- about these fields.
 data Msg1104 = Msg1104
   { _msg1104_header        :: MsmHeader
@@ -793,7 +793,7 @@ msg1105 = 1105
 --
 -- RTCMv3 message 1105.
 --
--- See RTCM spec and GLONASS signal specification for more information
+-- See RTCM spec and MSM signal specification for more information
 -- about these fields.
 data Msg1105 = Msg1105
   { _msg1105_header        :: MsmHeader
@@ -828,7 +828,7 @@ msg1106 = 1106
 --
 -- RTCMv3 message 1106.
 --
--- See RTCM spec and GLONASS signal specification for more information
+-- See RTCM spec and MSM signal specification for more information
 -- about these fields.
 data Msg1106 = Msg1106
   { _msg1106_header        :: MsmHeader
@@ -863,7 +863,7 @@ msg1107 = 1107
 --
 -- RTCMv3 message 1107.
 --
--- See RTCM spec and GLONASS signal specification for more information
+-- See RTCM spec and MSM signal specification for more information
 -- about these fields.
 data Msg1107 = Msg1107
   { _msg1107_header        :: MsmHeader
@@ -898,7 +898,7 @@ msg1114 = 1114
 --
 -- RTCMv3 message 1114.
 --
--- See RTCM spec and GLONASS signal specification for more information
+-- See RTCM spec and MSM signal specification for more information
 -- about these fields.
 data Msg1114 = Msg1114
   { _msg1114_header        :: MsmHeader
@@ -933,7 +933,7 @@ msg1115 = 1115
 --
 -- RTCMv3 message 1115.
 --
--- See RTCM spec and GLONASS signal specification for more information
+-- See RTCM spec and MSM signal specification for more information
 -- about these fields.
 data Msg1115 = Msg1115
   { _msg1115_header        :: MsmHeader
@@ -968,7 +968,7 @@ msg1116 = 1116
 --
 -- RTCMv3 message 1116.
 --
--- See RTCM spec and GLONASS signal specification for more information
+-- See RTCM spec and MSM signal specification for more information
 -- about these fields.
 data Msg1116 = Msg1116
   { _msg1116_header        :: MsmHeader
@@ -1003,7 +1003,7 @@ msg1117 = 1117
 --
 -- RTCMv3 message 1117.
 --
--- See RTCM spec and GLONASS signal specification for more information
+-- See RTCM spec and MSM signal specification for more information
 -- about these fields.
 data Msg1117 = Msg1117
   { _msg1117_header        :: MsmHeader
@@ -1038,7 +1038,7 @@ msg1124 = 1124
 --
 -- RTCMv3 message 1124.
 --
--- See RTCM spec and GLONASS signal specification for more information
+-- See RTCM spec and MSM signal specification for more information
 -- about these fields.
 data Msg1124 = Msg1124
   { _msg1124_header        :: MsmHeader
@@ -1073,7 +1073,7 @@ msg1125 = 1125
 --
 -- RTCMv3 message 1125.
 --
--- See RTCM spec and GLONASS signal specification for more information
+-- See RTCM spec and MSM signal specification for more information
 -- about these fields.
 data Msg1125 = Msg1125
   { _msg1125_header        :: MsmHeader
@@ -1108,7 +1108,7 @@ msg1126 = 1126
 --
 -- RTCMv3 message 1126.
 --
--- See RTCM spec and GLONASS signal specification for more information
+-- See RTCM spec and MSM signal specification for more information
 -- about these fields.
 data Msg1126 = Msg1126
   { _msg1126_header        :: MsmHeader
@@ -1143,7 +1143,7 @@ msg1127 = 1127
 --
 -- RTCMv3 message 1127.
 --
--- See RTCM spec and GLONASS signal specification for more information
+-- See RTCM spec and MSM signal specification for more information
 -- about these fields.
 data Msg1127 = Msg1127
   { _msg1127_header        :: MsmHeader

--- a/haskell/src/Data/RTCM3/MSM.hs
+++ b/haskell/src/Data/RTCM3/MSM.hs
@@ -111,6 +111,21 @@ data Msm46SatelliteData = Msm46SatelliteData
 $(makeLenses ''Msm46SatelliteData)
 $(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msm46SatelliteData_" . stripPrefix "_msm46SatelliteData_"} ''Msm46SatelliteData)
 
+-- | Get Bits for Msm4SatelliteData.
+--
+getBitsMsm46SatelliteData :: Int -> B.BitGet Msm46SatelliteData
+getBitsMsm46SatelliteData n = do
+  _msm46SatelliteData_roughRanges       <- replicateM n $ B.getWord8 8
+  _msm46SatelliteData_roughRangesModulo <- replicateM n $ B.getWord16be 10
+  pure Msm46SatelliteData {..}
+
+-- | Put Bits for Msm4SatelliteData.
+--
+putBitsMsm46SatelliteData :: Msm46SatelliteData -> B.BitPut ()
+putBitsMsm46SatelliteData Msm46SatelliteData {..} = do
+    forM_ _msm46SatelliteData_roughRanges $ B.putWord8 8
+    forM_ _msm46SatelliteData_roughRangesModulo $ B.putWord16be 10
+
 instance BinaryBit Msm46SatelliteData where
   getBits n = do
     _msm46SatelliteData_roughRanges       <- replicateM n $ B.getWord8 8
@@ -143,12 +158,12 @@ $(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msg1074_" . stripP
 instance Binary Msg1074 where
   get = B.runBitGet $ do
     _msg1074_header        <- getBits 0
-    _msg1074_satelliteData <- getBits $ popCount $ _msg1074_header ^. msmHeader_satelliteMask
+    _msg1074_satelliteData <- getBitsMsm46SatelliteData $ popCount $ _msg1074_header ^. msmHeader_satelliteMask
     pure Msg1074 {..}
 
   put Msg1074 {..} = B.runBitPut $ do
-    putBits 0 _msg1074_header
-    putBits 0 _msg1074_satelliteData
+    putBits 0                 _msg1074_header
+    putBitsMsm46SatelliteData _msg1074_satelliteData
 
 $(deriveRTCM3 ''Msg1074)
 
@@ -189,7 +204,7 @@ msg1076 = 1076
 -- See RTCM spec and GLONASS signal specification for more information
 -- about these fields.
 data Msg1076 = Msg1076
-  { _msg1076_header :: MsmHeader
+  { _msg1076_header        :: MsmHeader
     -- ^ MSM header.
   , _msg1076_satelliteData :: Msm46SatelliteData
     -- ^ MSM satellite data.
@@ -201,12 +216,12 @@ $(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msg1076_" . stripP
 instance Binary Msg1076 where
   get = B.runBitGet $ do
     _msg1076_header        <- getBits 0
-    _msg1076_satelliteData <- getBits $ popCount $ _msg1076_header ^. msmHeader_satelliteMask
+    _msg1076_satelliteData <- getBitsMsm46SatelliteData $ popCount $ _msg1076_header ^. msmHeader_satelliteMask
     pure Msg1076 {..}
 
   put Msg1076 {..} = B.runBitPut $ do
-    putBits 0 _msg1076_header
-    putBits 0 _msg1076_satelliteData
+    putBits 0                 _msg1076_header
+    putBitsMsm46SatelliteData _msg1076_satelliteData
 
 $(deriveRTCM3 ''Msg1076)
 
@@ -247,8 +262,10 @@ msg1084 = 1084
 -- See RTCM spec and GLONASS signal specification for more information
 -- about these fields.
 data Msg1084 = Msg1084
-  { _msg1084_header :: MsmHeader
+  { _msg1084_header        :: MsmHeader
     -- ^ MSM header.
+  , _msg1084_satelliteData :: Msm46SatelliteData
+    -- ^ MSM satellite data.
   } deriving ( Show, Read, Eq )
 
 $(makeLenses ''Msg1084)
@@ -256,11 +273,13 @@ $(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msg1084_" . stripP
 
 instance Binary Msg1084 where
   get = B.runBitGet $ do
-    _msg1084_header <- getBits 0
+    _msg1084_header        <- getBits 0
+    _msg1084_satelliteData <- getBitsMsm46SatelliteData $ popCount $ _msg1084_header ^. msmHeader_satelliteMask
     pure Msg1084 {..}
 
   put Msg1084 {..} = B.runBitPut $ do
-    putBits 0 _msg1084_header
+    putBits 0                 _msg1084_header
+    putBitsMsm46SatelliteData _msg1084_satelliteData
 
 $(deriveRTCM3 ''Msg1084)
 
@@ -301,8 +320,10 @@ msg1086 = 1086
 -- See RTCM spec and GLONASS signal specification for more information
 -- about these fields.
 data Msg1086 = Msg1086
-  { _msg1086_header :: MsmHeader
+  { _msg1086_header        :: MsmHeader
     -- ^ MSM header.
+  , _msg1086_satelliteData :: Msm46SatelliteData
+    -- ^ MSM satellite data.
   } deriving ( Show, Read, Eq )
 
 $(makeLenses ''Msg1086)
@@ -310,11 +331,13 @@ $(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msg1086_" . stripP
 
 instance Binary Msg1086 where
   get = B.runBitGet $ do
-    _msg1086_header <- getBits 0
+    _msg1086_header        <- getBits 0
+    _msg1086_satelliteData <- getBitsMsm46SatelliteData $ popCount $ _msg1086_header ^. msmHeader_satelliteMask
     pure Msg1086 {..}
 
   put Msg1086 {..} = B.runBitPut $ do
-    putBits 0 _msg1086_header
+    putBits 0                 _msg1086_header
+    putBitsMsm46SatelliteData _msg1086_satelliteData
 
 $(deriveRTCM3 ''Msg1086)
 
@@ -355,8 +378,10 @@ msg1094 = 1094
 -- See RTCM spec and GLONASS signal specification for more information
 -- about these fields.
 data Msg1094 = Msg1094
-  { _msg1094_header :: MsmHeader
+  { _msg1094_header        :: MsmHeader
     -- ^ MSM header.
+  , _msg1094_satelliteData :: Msm46SatelliteData
+    -- ^ MSM satellite data.
   } deriving ( Show, Read, Eq )
 
 $(makeLenses ''Msg1094)
@@ -364,11 +389,13 @@ $(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msg1094_" . stripP
 
 instance Binary Msg1094 where
   get = B.runBitGet $ do
-    _msg1094_header <- getBits 0
+    _msg1094_header        <- getBits 0
+    _msg1094_satelliteData <- getBitsMsm46SatelliteData $ popCount $ _msg1094_header ^. msmHeader_satelliteMask
     pure Msg1094 {..}
 
   put Msg1094 {..} = B.runBitPut $ do
-    putBits 0 _msg1094_header
+    putBits 0                 _msg1094_header
+    putBitsMsm46SatelliteData _msg1094_satelliteData
 
 $(deriveRTCM3 ''Msg1094)
 
@@ -409,8 +436,10 @@ msg1096 = 1096
 -- See RTCM spec and GLONASS signal specification for more information
 -- about these fields.
 data Msg1096 = Msg1096
-  { _msg1096_header :: MsmHeader
+  { _msg1096_header        :: MsmHeader
     -- ^ MSM header.
+  , _msg1096_satelliteData :: Msm46SatelliteData
+    -- ^ MSM satellite data.
   } deriving ( Show, Read, Eq )
 
 $(makeLenses ''Msg1096)
@@ -418,11 +447,13 @@ $(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msg1096_" . stripP
 
 instance Binary Msg1096 where
   get = B.runBitGet $ do
-    _msg1096_header <- getBits 0
+    _msg1096_header        <- getBits 0
+    _msg1096_satelliteData <- getBitsMsm46SatelliteData $ popCount $ _msg1096_header ^. msmHeader_satelliteMask
     pure Msg1096 {..}
 
   put Msg1096 {..} = B.runBitPut $ do
-    putBits 0 _msg1096_header
+    putBits 0                 _msg1096_header
+    putBitsMsm46SatelliteData _msg1096_satelliteData
 
 $(deriveRTCM3 ''Msg1096)
 
@@ -463,8 +494,10 @@ msg1104 = 1104
 -- See RTCM spec and GLONASS signal specification for more information
 -- about these fields.
 data Msg1104 = Msg1104
-  { _msg1104_header :: MsmHeader
+  { _msg1104_header        :: MsmHeader
     -- ^ MSM header.
+  , _msg1104_satelliteData :: Msm46SatelliteData
+    -- ^ MSM satellite data.
   } deriving ( Show, Read, Eq )
 
 $(makeLenses ''Msg1104)
@@ -472,11 +505,13 @@ $(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msg1104_" . stripP
 
 instance Binary Msg1104 where
   get = B.runBitGet $ do
-    _msg1104_header <- getBits 0
+    _msg1104_header        <- getBits 0
+    _msg1104_satelliteData <- getBitsMsm46SatelliteData $ popCount $ _msg1104_header ^. msmHeader_satelliteMask
     pure Msg1104 {..}
 
   put Msg1104 {..} = B.runBitPut $ do
-    putBits 0 _msg1104_header
+    putBits 0                 _msg1104_header
+    putBitsMsm46SatelliteData _msg1104_satelliteData
 
 $(deriveRTCM3 ''Msg1104)
 
@@ -517,8 +552,10 @@ msg1106 = 1106
 -- See RTCM spec and GLONASS signal specification for more information
 -- about these fields.
 data Msg1106 = Msg1106
-  { _msg1106_header :: MsmHeader
+  { _msg1106_header        :: MsmHeader
     -- ^ MSM header.
+  , _msg1106_satelliteData :: Msm46SatelliteData
+    -- ^ MSM satellite data.
   } deriving ( Show, Read, Eq )
 
 $(makeLenses ''Msg1106)
@@ -526,11 +563,13 @@ $(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msg1106_" . stripP
 
 instance Binary Msg1106 where
   get = B.runBitGet $ do
-    _msg1106_header <- getBits 0
+    _msg1106_header        <- getBits 0
+    _msg1106_satelliteData <- getBitsMsm46SatelliteData $ popCount $ _msg1106_header ^. msmHeader_satelliteMask
     pure Msg1106 {..}
 
   put Msg1106 {..} = B.runBitPut $ do
-    putBits 0 _msg1106_header
+    putBits 0                 _msg1106_header
+    putBitsMsm46SatelliteData _msg1106_satelliteData
 
 $(deriveRTCM3 ''Msg1106)
 
@@ -571,8 +610,10 @@ msg1114 = 1114
 -- See RTCM spec and GLONASS signal specification for more information
 -- about these fields.
 data Msg1114 = Msg1114
-  { _msg1114_header :: MsmHeader
+  { _msg1114_header        :: MsmHeader
     -- ^ MSM header.
+  , _msg1114_satelliteData :: Msm46SatelliteData
+    -- ^ MSM satellite data.
   } deriving ( Show, Read, Eq )
 
 $(makeLenses ''Msg1114)
@@ -580,11 +621,13 @@ $(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msg1114_" . stripP
 
 instance Binary Msg1114 where
   get = B.runBitGet $ do
-    _msg1114_header <- getBits 0
+    _msg1114_header        <- getBits 0
+    _msg1114_satelliteData <- getBitsMsm46SatelliteData $ popCount $ _msg1114_header ^. msmHeader_satelliteMask
     pure Msg1114 {..}
 
   put Msg1114 {..} = B.runBitPut $ do
-    putBits 0 _msg1114_header
+    putBits 0                 _msg1114_header
+    putBitsMsm46SatelliteData _msg1114_satelliteData
 
 $(deriveRTCM3 ''Msg1114)
 
@@ -625,8 +668,10 @@ msg1116 = 1116
 -- See RTCM spec and GLONASS signal specification for more information
 -- about these fields.
 data Msg1116 = Msg1116
-  { _msg1116_header :: MsmHeader
+  { _msg1116_header        :: MsmHeader
     -- ^ MSM header.
+  , _msg1116_satelliteData :: Msm46SatelliteData
+    -- ^ MSM satellite data.
   } deriving ( Show, Read, Eq )
 
 $(makeLenses ''Msg1116)
@@ -634,11 +679,13 @@ $(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msg1116_" . stripP
 
 instance Binary Msg1116 where
   get = B.runBitGet $ do
-    _msg1116_header <- getBits 0
+    _msg1116_header        <- getBits 0
+    _msg1116_satelliteData <- getBitsMsm46SatelliteData $ popCount $ _msg1116_header ^. msmHeader_satelliteMask
     pure Msg1116 {..}
 
   put Msg1116 {..} = B.runBitPut $ do
-    putBits 0 _msg1116_header
+    putBits 0                 _msg1116_header
+    putBitsMsm46SatelliteData _msg1116_satelliteData
 
 $(deriveRTCM3 ''Msg1116)
 
@@ -679,8 +726,10 @@ msg1124 = 1124
 -- See RTCM spec and GLONASS signal specification for more information
 -- about these fields.
 data Msg1124 = Msg1124
-  { _msg1124_header :: MsmHeader
+  { _msg1124_header        :: MsmHeader
     -- ^ MSM header.
+  , _msg1124_satelliteData :: Msm46SatelliteData
+    -- ^ MSM satellite data.
   } deriving ( Show, Read, Eq )
 
 $(makeLenses ''Msg1124)
@@ -688,11 +737,13 @@ $(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msg1124_" . stripP
 
 instance Binary Msg1124 where
   get = B.runBitGet $ do
-    _msg1124_header <- getBits 0
+    _msg1124_header        <- getBits 0
+    _msg1124_satelliteData <- getBitsMsm46SatelliteData $ popCount $ _msg1124_header ^. msmHeader_satelliteMask
     pure Msg1124 {..}
 
   put Msg1124 {..} = B.runBitPut $ do
-    putBits 0 _msg1124_header
+    putBits 0                 _msg1124_header
+    putBitsMsm46SatelliteData _msg1124_satelliteData
 
 $(deriveRTCM3 ''Msg1124)
 
@@ -733,8 +784,10 @@ msg1126 = 1126
 -- See RTCM spec and GLONASS signal specification for more information
 -- about these fields.
 data Msg1126 = Msg1126
-  { _msg1126_header :: MsmHeader
+  { _msg1126_header        :: MsmHeader
     -- ^ MSM header.
+  , _msg1126_satelliteData :: Msm46SatelliteData
+    -- ^ MSM satellite data.
   } deriving ( Show, Read, Eq )
 
 $(makeLenses ''Msg1126)
@@ -742,11 +795,13 @@ $(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msg1126_" . stripP
 
 instance Binary Msg1126 where
   get = B.runBitGet $ do
-    _msg1126_header <- getBits 0
+    _msg1126_header        <- getBits 0
+    _msg1126_satelliteData <- getBitsMsm46SatelliteData $ popCount $ _msg1126_header ^. msmHeader_satelliteMask
     pure Msg1126 {..}
 
   put Msg1126 {..} = B.runBitPut $ do
-    putBits 0 _msg1126_header
+    putBits 0                 _msg1126_header
+    putBitsMsm46SatelliteData _msg1126_satelliteData
 
 $(deriveRTCM3 ''Msg1126)
 

--- a/haskell/src/Data/RTCM3/MSM.hs
+++ b/haskell/src/Data/RTCM3/MSM.hs
@@ -1,0 +1,125 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE TemplateHaskell   #-}
+
+-- |
+-- Module:      Data.RTCM3.MSM
+-- Copyright:   Copyright (C) 2018 Swift Navigation, Inc.
+-- License:     LGPL-3
+-- Maintainer:  Swift Navigation <dev@swiftnav.com>
+-- Stability:   experimental
+-- Portability: portable
+--
+-- RTCMv3 messages for Multiple Signal Messages.
+
+module Data.RTCM3.MSM
+  ( module Data.RTCM3.MSM
+  ) where
+
+import           BasicPrelude
+import           Control.Lens
+import           Data.Aeson.TH
+import           Data.Binary
+import           Data.Binary.Bits
+import qualified Data.Binary.Bits.Get as B
+import qualified Data.Binary.Bits.Put as B
+import           Data.Bits
+import           Data.RTCM3.TH
+
+{-# ANN module ("HLint: ignore Use camelCase"::String) #-}
+
+-- | MsmHeader.
+--
+-- MSM observation header.
+data MsmHeader = MsmHeader
+  { _msmHeader_num               :: Word16
+    -- ^ Message number.
+  , _msmHeader_station           :: Word16
+    -- ^ Reference station id.
+  , _msmHeader_epoch             :: Word32
+    -- ^ GNSS epoch time.
+  , _msmHeader_multiple          :: Bool
+    -- ^ Multiple message indicator.
+  , _msmHeader_iods              :: Word8
+    -- ^ Issue of data station.
+  , _msmHeader_reserved          :: Word8
+    -- ^ Reserved.
+  , _msmHeader_clockSteering     :: Word8
+    -- ^ Clock steering indicator.
+  , _msmHeader_externalClock     :: Word8
+    -- ^ External clock indicator.
+  , _msmHeader_smoothing         :: Bool
+    -- ^ GNSS divergence-free smoothing indicator.
+  , _msmHeader_smoothingInterval :: Word8
+    -- ^ GNSS smoothing interval.
+  , _msmHeader_satelliteMask     :: Word64
+    -- ^ GNSS satellite mask.
+  , _msmHeader_signalMask        :: Word32
+    -- ^ GNSS signal mask.
+  , _msmHeader_cellMask          :: Word64
+    -- ^ GNSS cell mask.
+  } deriving ( Show, Read, Eq )
+
+$(makeLenses ''MsmHeader)
+$(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msmHeader_" . stripPrefix "_msmHeader_"} ''MsmHeader)
+
+instance BinaryBit MsmHeader where
+  getBits _n = do
+    _msmHeader_num               <- B.getWord16be 12
+    _msmHeader_station           <- B.getWord16be 12
+    _msmHeader_epoch             <- B.getWord32be 30
+    _msmHeader_multiple          <- B.getBool
+    _msmHeader_iods              <- B.getWord8 3
+    _msmHeader_reserved          <- B.getWord8 7
+    _msmHeader_clockSteering     <- B.getWord8 2
+    _msmHeader_externalClock     <- B.getWord8 2
+    _msmHeader_smoothing         <- B.getBool
+    _msmHeader_smoothingInterval <- B.getWord8 3
+    _msmHeader_satelliteMask     <- B.getWord64be 64
+    _msmHeader_signalMask        <- B.getWord32be 32
+    let x = min 64 $ popCount _msmHeader_satelliteMask * popCount _msmHeader_signalMask
+    _msmHeader_cellMask          <- B.getWord64be x
+    pure MsmHeader {..}
+
+  putBits _n MsmHeader {..} = do
+    B.putWord16be 12 _msmHeader_num
+    B.putWord16be 12 _msmHeader_station
+    B.putWord32be 30 _msmHeader_epoch
+    B.putBool        _msmHeader_multiple
+    B.putWord8 3     _msmHeader_iods
+    B.putWord8 7     _msmHeader_reserved
+    B.putWord8 2     _msmHeader_clockSteering
+    B.putWord8 2     _msmHeader_externalClock
+    B.putBool        _msmHeader_smoothing
+    B.putWord8 3     _msmHeader_smoothingInterval
+    B.putWord64be 64 _msmHeader_satelliteMask
+    B.putWord32be 32 _msmHeader_signalMask
+    let x = min 64 $ popCount _msmHeader_satelliteMask * popCount _msmHeader_signalMask
+    B.putWord64be x  _msmHeader_cellMask
+
+msg1074 :: Word16
+msg1074 = 1074
+
+-- | Message 1074
+--
+-- RTCMv3 message 1074.
+--
+-- See RTCM spec and GLONASS signal specification for more information
+-- about these fields.
+data Msg1074 = Msg1074
+  { _msg1074_header :: MsmHeader
+    -- ^ MSM header.
+  } deriving ( Show, Read, Eq )
+
+$(makeLenses ''Msg1074)
+$(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msg1074_" . stripPrefix "_msg1074_"} ''Msg1074)
+
+instance Binary Msg1074 where
+  get = B.runBitGet $ do
+    _msg1074_header <- getBits 0
+    pure Msg1074 {..}
+
+  put Msg1074 {..} = B.runBitPut $ do
+    putBits 0 _msg1074_header
+
+$(deriveRTCM3 ''Msg1074)

--- a/haskell/src/Data/RTCM3/MSM.hs
+++ b/haskell/src/Data/RTCM3/MSM.hs
@@ -123,3 +123,625 @@ instance Binary Msg1074 where
     putBits 0 _msg1074_header
 
 $(deriveRTCM3 ''Msg1074)
+
+msg1075 :: Word16
+msg1075 = 1075
+
+-- | Message 1075
+--
+-- RTCMv3 message 1075.
+--
+-- See RTCM spec and GLONASS signal specification for more information
+-- about these fields.
+data Msg1075 = Msg1075
+  { _msg1075_header :: MsmHeader
+    -- ^ MSM header.
+  } deriving ( Show, Read, Eq )
+
+$(makeLenses ''Msg1075)
+$(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msg1075_" . stripPrefix "_msg1075_"} ''Msg1075)
+
+instance Binary Msg1075 where
+  get = B.runBitGet $ do
+    _msg1075_header <- getBits 0
+    pure Msg1075 {..}
+
+  put Msg1075 {..} = B.runBitPut $ do
+    putBits 0 _msg1075_header
+
+$(deriveRTCM3 ''Msg1075)
+
+msg1076 :: Word16
+msg1076 = 1076
+
+-- | Message 1076
+--
+-- RTCMv3 message 1076.
+--
+-- See RTCM spec and GLONASS signal specification for more information
+-- about these fields.
+data Msg1076 = Msg1076
+  { _msg1076_header :: MsmHeader
+    -- ^ MSM header.
+  } deriving ( Show, Read, Eq )
+
+$(makeLenses ''Msg1076)
+$(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msg1076_" . stripPrefix "_msg1076_"} ''Msg1076)
+
+instance Binary Msg1076 where
+  get = B.runBitGet $ do
+    _msg1076_header <- getBits 0
+    pure Msg1076 {..}
+
+  put Msg1076 {..} = B.runBitPut $ do
+    putBits 0 _msg1076_header
+
+$(deriveRTCM3 ''Msg1076)
+
+msg1077 :: Word16
+msg1077 = 1077
+
+-- | Message 1077
+--
+-- RTCMv3 message 1077.
+--
+-- See RTCM spec and GLONASS signal specification for more information
+-- about these fields.
+data Msg1077 = Msg1077
+  { _msg1077_header :: MsmHeader
+    -- ^ MSM header.
+  } deriving ( Show, Read, Eq )
+
+$(makeLenses ''Msg1077)
+$(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msg1077_" . stripPrefix "_msg1077_"} ''Msg1077)
+
+instance Binary Msg1077 where
+  get = B.runBitGet $ do
+    _msg1077_header <- getBits 0
+    pure Msg1077 {..}
+
+  put Msg1077 {..} = B.runBitPut $ do
+    putBits 0 _msg1077_header
+
+$(deriveRTCM3 ''Msg1077)
+
+msg1084 :: Word16
+msg1084 = 1084
+
+-- | Message 1084
+--
+-- RTCMv3 message 1084.
+--
+-- See RTCM spec and GLONASS signal specification for more information
+-- about these fields.
+data Msg1084 = Msg1084
+  { _msg1084_header :: MsmHeader
+    -- ^ MSM header.
+  } deriving ( Show, Read, Eq )
+
+$(makeLenses ''Msg1084)
+$(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msg1084_" . stripPrefix "_msg1084_"} ''Msg1084)
+
+instance Binary Msg1084 where
+  get = B.runBitGet $ do
+    _msg1084_header <- getBits 0
+    pure Msg1084 {..}
+
+  put Msg1084 {..} = B.runBitPut $ do
+    putBits 0 _msg1084_header
+
+$(deriveRTCM3 ''Msg1084)
+
+msg1085 :: Word16
+msg1085 = 1085
+
+-- | Message 1085
+--
+-- RTCMv3 message 1085.
+--
+-- See RTCM spec and GLONASS signal specification for more information
+-- about these fields.
+data Msg1085 = Msg1085
+  { _msg1085_header :: MsmHeader
+    -- ^ MSM header.
+  } deriving ( Show, Read, Eq )
+
+$(makeLenses ''Msg1085)
+$(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msg1085_" . stripPrefix "_msg1085_"} ''Msg1085)
+
+instance Binary Msg1085 where
+  get = B.runBitGet $ do
+    _msg1085_header <- getBits 0
+    pure Msg1085 {..}
+
+  put Msg1085 {..} = B.runBitPut $ do
+    putBits 0 _msg1085_header
+
+$(deriveRTCM3 ''Msg1085)
+
+msg1086 :: Word16
+msg1086 = 1086
+
+-- | Message 1086
+--
+-- RTCMv3 message 1086.
+--
+-- See RTCM spec and GLONASS signal specification for more information
+-- about these fields.
+data Msg1086 = Msg1086
+  { _msg1086_header :: MsmHeader
+    -- ^ MSM header.
+  } deriving ( Show, Read, Eq )
+
+$(makeLenses ''Msg1086)
+$(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msg1086_" . stripPrefix "_msg1086_"} ''Msg1086)
+
+instance Binary Msg1086 where
+  get = B.runBitGet $ do
+    _msg1086_header <- getBits 0
+    pure Msg1086 {..}
+
+  put Msg1086 {..} = B.runBitPut $ do
+    putBits 0 _msg1086_header
+
+$(deriveRTCM3 ''Msg1086)
+
+msg1087 :: Word16
+msg1087 = 1087
+
+-- | Message 1087
+--
+-- RTCMv3 message 1087.
+--
+-- See RTCM spec and GLONASS signal specification for more information
+-- about these fields.
+data Msg1087 = Msg1087
+  { _msg1087_header :: MsmHeader
+    -- ^ MSM header.
+  } deriving ( Show, Read, Eq )
+
+$(makeLenses ''Msg1087)
+$(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msg1087_" . stripPrefix "_msg1087_"} ''Msg1087)
+
+instance Binary Msg1087 where
+  get = B.runBitGet $ do
+    _msg1087_header <- getBits 0
+    pure Msg1087 {..}
+
+  put Msg1087 {..} = B.runBitPut $ do
+    putBits 0 _msg1087_header
+
+$(deriveRTCM3 ''Msg1087)
+
+msg1094 :: Word16
+msg1094 = 1094
+
+-- | Message 1094
+--
+-- RTCMv3 message 1094.
+--
+-- See RTCM spec and GLONASS signal specification for more information
+-- about these fields.
+data Msg1094 = Msg1094
+  { _msg1094_header :: MsmHeader
+    -- ^ MSM header.
+  } deriving ( Show, Read, Eq )
+
+$(makeLenses ''Msg1094)
+$(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msg1094_" . stripPrefix "_msg1094_"} ''Msg1094)
+
+instance Binary Msg1094 where
+  get = B.runBitGet $ do
+    _msg1094_header <- getBits 0
+    pure Msg1094 {..}
+
+  put Msg1094 {..} = B.runBitPut $ do
+    putBits 0 _msg1094_header
+
+$(deriveRTCM3 ''Msg1094)
+
+msg1095 :: Word16
+msg1095 = 1095
+
+-- | Message 1095
+--
+-- RTCMv3 message 1095.
+--
+-- See RTCM spec and GLONASS signal specification for more information
+-- about these fields.
+data Msg1095 = Msg1095
+  { _msg1095_header :: MsmHeader
+    -- ^ MSM header.
+  } deriving ( Show, Read, Eq )
+
+$(makeLenses ''Msg1095)
+$(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msg1095_" . stripPrefix "_msg1095_"} ''Msg1095)
+
+instance Binary Msg1095 where
+  get = B.runBitGet $ do
+    _msg1095_header <- getBits 0
+    pure Msg1095 {..}
+
+  put Msg1095 {..} = B.runBitPut $ do
+    putBits 0 _msg1095_header
+
+$(deriveRTCM3 ''Msg1095)
+
+msg1096 :: Word16
+msg1096 = 1096
+
+-- | Message 1096
+--
+-- RTCMv3 message 1096.
+--
+-- See RTCM spec and GLONASS signal specification for more information
+-- about these fields.
+data Msg1096 = Msg1096
+  { _msg1096_header :: MsmHeader
+    -- ^ MSM header.
+  } deriving ( Show, Read, Eq )
+
+$(makeLenses ''Msg1096)
+$(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msg1096_" . stripPrefix "_msg1096_"} ''Msg1096)
+
+instance Binary Msg1096 where
+  get = B.runBitGet $ do
+    _msg1096_header <- getBits 0
+    pure Msg1096 {..}
+
+  put Msg1096 {..} = B.runBitPut $ do
+    putBits 0 _msg1096_header
+
+$(deriveRTCM3 ''Msg1096)
+
+msg1097 :: Word16
+msg1097 = 1097
+
+-- | Message 1097
+--
+-- RTCMv3 message 1097.
+--
+-- See RTCM spec and GLONASS signal specification for more information
+-- about these fields.
+data Msg1097 = Msg1097
+  { _msg1097_header :: MsmHeader
+    -- ^ MSM header.
+  } deriving ( Show, Read, Eq )
+
+$(makeLenses ''Msg1097)
+$(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msg1097_" . stripPrefix "_msg1097_"} ''Msg1097)
+
+instance Binary Msg1097 where
+  get = B.runBitGet $ do
+    _msg1097_header <- getBits 0
+    pure Msg1097 {..}
+
+  put Msg1097 {..} = B.runBitPut $ do
+    putBits 0 _msg1097_header
+
+$(deriveRTCM3 ''Msg1097)
+
+msg1104 :: Word16
+msg1104 = 1104
+
+-- | Message 1104
+--
+-- RTCMv3 message 1104.
+--
+-- See RTCM spec and GLONASS signal specification for more information
+-- about these fields.
+data Msg1104 = Msg1104
+  { _msg1104_header :: MsmHeader
+    -- ^ MSM header.
+  } deriving ( Show, Read, Eq )
+
+$(makeLenses ''Msg1104)
+$(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msg1104_" . stripPrefix "_msg1104_"} ''Msg1104)
+
+instance Binary Msg1104 where
+  get = B.runBitGet $ do
+    _msg1104_header <- getBits 0
+    pure Msg1104 {..}
+
+  put Msg1104 {..} = B.runBitPut $ do
+    putBits 0 _msg1104_header
+
+$(deriveRTCM3 ''Msg1104)
+
+msg1105 :: Word16
+msg1105 = 1105
+
+-- | Message 1105
+--
+-- RTCMv3 message 1105.
+--
+-- See RTCM spec and GLONASS signal specification for more information
+-- about these fields.
+data Msg1105 = Msg1105
+  { _msg1105_header :: MsmHeader
+    -- ^ MSM header.
+  } deriving ( Show, Read, Eq )
+
+$(makeLenses ''Msg1105)
+$(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msg1105_" . stripPrefix "_msg1105_"} ''Msg1105)
+
+instance Binary Msg1105 where
+  get = B.runBitGet $ do
+    _msg1105_header <- getBits 0
+    pure Msg1105 {..}
+
+  put Msg1105 {..} = B.runBitPut $ do
+    putBits 0 _msg1105_header
+
+$(deriveRTCM3 ''Msg1105)
+
+msg1106 :: Word16
+msg1106 = 1106
+
+-- | Message 1106
+--
+-- RTCMv3 message 1106.
+--
+-- See RTCM spec and GLONASS signal specification for more information
+-- about these fields.
+data Msg1106 = Msg1106
+  { _msg1106_header :: MsmHeader
+    -- ^ MSM header.
+  } deriving ( Show, Read, Eq )
+
+$(makeLenses ''Msg1106)
+$(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msg1106_" . stripPrefix "_msg1106_"} ''Msg1106)
+
+instance Binary Msg1106 where
+  get = B.runBitGet $ do
+    _msg1106_header <- getBits 0
+    pure Msg1106 {..}
+
+  put Msg1106 {..} = B.runBitPut $ do
+    putBits 0 _msg1106_header
+
+$(deriveRTCM3 ''Msg1106)
+
+msg1107 :: Word16
+msg1107 = 1107
+
+-- | Message 1107
+--
+-- RTCMv3 message 1107.
+--
+-- See RTCM spec and GLONASS signal specification for more information
+-- about these fields.
+data Msg1107 = Msg1107
+  { _msg1107_header :: MsmHeader
+    -- ^ MSM header.
+  } deriving ( Show, Read, Eq )
+
+$(makeLenses ''Msg1107)
+$(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msg1107_" . stripPrefix "_msg1107_"} ''Msg1107)
+
+instance Binary Msg1107 where
+  get = B.runBitGet $ do
+    _msg1107_header <- getBits 0
+    pure Msg1107 {..}
+
+  put Msg1107 {..} = B.runBitPut $ do
+    putBits 0 _msg1107_header
+
+$(deriveRTCM3 ''Msg1107)
+
+msg1114 :: Word16
+msg1114 = 1114
+
+-- | Message 1114
+--
+-- RTCMv3 message 1114.
+--
+-- See RTCM spec and GLONASS signal specification for more information
+-- about these fields.
+data Msg1114 = Msg1114
+  { _msg1114_header :: MsmHeader
+    -- ^ MSM header.
+  } deriving ( Show, Read, Eq )
+
+$(makeLenses ''Msg1114)
+$(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msg1114_" . stripPrefix "_msg1114_"} ''Msg1114)
+
+instance Binary Msg1114 where
+  get = B.runBitGet $ do
+    _msg1114_header <- getBits 0
+    pure Msg1114 {..}
+
+  put Msg1114 {..} = B.runBitPut $ do
+    putBits 0 _msg1114_header
+
+$(deriveRTCM3 ''Msg1114)
+
+msg1115 :: Word16
+msg1115 = 1115
+
+-- | Message 1115
+--
+-- RTCMv3 message 1115.
+--
+-- See RTCM spec and GLONASS signal specification for more information
+-- about these fields.
+data Msg1115 = Msg1115
+  { _msg1115_header :: MsmHeader
+    -- ^ MSM header.
+  } deriving ( Show, Read, Eq )
+
+$(makeLenses ''Msg1115)
+$(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msg1115_" . stripPrefix "_msg1115_"} ''Msg1115)
+
+instance Binary Msg1115 where
+  get = B.runBitGet $ do
+    _msg1115_header <- getBits 0
+    pure Msg1115 {..}
+
+  put Msg1115 {..} = B.runBitPut $ do
+    putBits 0 _msg1115_header
+
+$(deriveRTCM3 ''Msg1115)
+
+msg1116 :: Word16
+msg1116 = 1116
+
+-- | Message 1116
+--
+-- RTCMv3 message 1116.
+--
+-- See RTCM spec and GLONASS signal specification for more information
+-- about these fields.
+data Msg1116 = Msg1116
+  { _msg1116_header :: MsmHeader
+    -- ^ MSM header.
+  } deriving ( Show, Read, Eq )
+
+$(makeLenses ''Msg1116)
+$(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msg1116_" . stripPrefix "_msg1116_"} ''Msg1116)
+
+instance Binary Msg1116 where
+  get = B.runBitGet $ do
+    _msg1116_header <- getBits 0
+    pure Msg1116 {..}
+
+  put Msg1116 {..} = B.runBitPut $ do
+    putBits 0 _msg1116_header
+
+$(deriveRTCM3 ''Msg1116)
+
+msg1117 :: Word16
+msg1117 = 1117
+
+-- | Message 1117
+--
+-- RTCMv3 message 1117.
+--
+-- See RTCM spec and GLONASS signal specification for more information
+-- about these fields.
+data Msg1117 = Msg1117
+  { _msg1117_header :: MsmHeader
+    -- ^ MSM header.
+  } deriving ( Show, Read, Eq )
+
+$(makeLenses ''Msg1117)
+$(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msg1117_" . stripPrefix "_msg1117_"} ''Msg1117)
+
+instance Binary Msg1117 where
+  get = B.runBitGet $ do
+    _msg1117_header <- getBits 0
+    pure Msg1117 {..}
+
+  put Msg1117 {..} = B.runBitPut $ do
+    putBits 0 _msg1117_header
+
+$(deriveRTCM3 ''Msg1117)
+
+msg1124 :: Word16
+msg1124 = 1124
+
+-- | Message 1124
+--
+-- RTCMv3 message 1124.
+--
+-- See RTCM spec and GLONASS signal specification for more information
+-- about these fields.
+data Msg1124 = Msg1124
+  { _msg1124_header :: MsmHeader
+    -- ^ MSM header.
+  } deriving ( Show, Read, Eq )
+
+$(makeLenses ''Msg1124)
+$(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msg1124_" . stripPrefix "_msg1124_"} ''Msg1124)
+
+instance Binary Msg1124 where
+  get = B.runBitGet $ do
+    _msg1124_header <- getBits 0
+    pure Msg1124 {..}
+
+  put Msg1124 {..} = B.runBitPut $ do
+    putBits 0 _msg1124_header
+
+$(deriveRTCM3 ''Msg1124)
+
+msg1125 :: Word16
+msg1125 = 1125
+
+-- | Message 1125
+--
+-- RTCMv3 message 1125.
+--
+-- See RTCM spec and GLONASS signal specification for more information
+-- about these fields.
+data Msg1125 = Msg1125
+  { _msg1125_header :: MsmHeader
+    -- ^ MSM header.
+  } deriving ( Show, Read, Eq )
+
+$(makeLenses ''Msg1125)
+$(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msg1125_" . stripPrefix "_msg1125_"} ''Msg1125)
+
+instance Binary Msg1125 where
+  get = B.runBitGet $ do
+    _msg1125_header <- getBits 0
+    pure Msg1125 {..}
+
+  put Msg1125 {..} = B.runBitPut $ do
+    putBits 0 _msg1125_header
+
+$(deriveRTCM3 ''Msg1125)
+
+msg1126 :: Word16
+msg1126 = 1126
+
+-- | Message 1126
+--
+-- RTCMv3 message 1126.
+--
+-- See RTCM spec and GLONASS signal specification for more information
+-- about these fields.
+data Msg1126 = Msg1126
+  { _msg1126_header :: MsmHeader
+    -- ^ MSM header.
+  } deriving ( Show, Read, Eq )
+
+$(makeLenses ''Msg1126)
+$(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msg1126_" . stripPrefix "_msg1126_"} ''Msg1126)
+
+instance Binary Msg1126 where
+  get = B.runBitGet $ do
+    _msg1126_header <- getBits 0
+    pure Msg1126 {..}
+
+  put Msg1126 {..} = B.runBitPut $ do
+    putBits 0 _msg1126_header
+
+$(deriveRTCM3 ''Msg1126)
+
+msg1127 :: Word16
+msg1127 = 1127
+
+-- | Message 1127
+--
+-- RTCMv3 message 1127.
+--
+-- See RTCM spec and GLONASS signal specification for more information
+-- about these fields.
+data Msg1127 = Msg1127
+  { _msg1127_header :: MsmHeader
+    -- ^ MSM header.
+  } deriving ( Show, Read, Eq )
+
+$(makeLenses ''Msg1127)
+$(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msg1127_" . stripPrefix "_msg1127_"} ''Msg1127)
+
+instance Binary Msg1127 where
+  get = B.runBitGet $ do
+    _msg1127_header <- getBits 0
+    pure Msg1127 {..}
+
+  put Msg1127 {..} = B.runBitPut $ do
+    putBits 0 _msg1127_header
+
+$(deriveRTCM3 ''Msg1127)
+

--- a/haskell/src/Data/RTCM3/MSM.hs
+++ b/haskell/src/Data/RTCM3/MSM.hs
@@ -24,6 +24,8 @@ import           Data.Binary.Bits
 import qualified Data.Binary.Bits.Get as B
 import qualified Data.Binary.Bits.Put as B
 import           Data.Bits
+import           Data.Int
+import           Data.RTCM3.Extras
 import           Data.RTCM3.TH
 
 {-# ANN module ("HLint: ignore Use camelCase"::String) #-}
@@ -122,8 +124,8 @@ getBitsMsm46SatelliteData n = do
 --
 putBitsMsm46SatelliteData :: Msm46SatelliteData -> B.BitPut ()
 putBitsMsm46SatelliteData Msm46SatelliteData {..} = do
-    forM_ _msm46SatelliteData_roughRanges $ B.putWord8 8
-    forM_ _msm46SatelliteData_roughRangesModulo $ B.putWord16be 10
+  forM_ _msm46SatelliteData_roughRanges $ B.putWord8 8
+  forM_ _msm46SatelliteData_roughRangesModulo $ B.putWord16be 10
 
 -- | Msm57SatelliteData
 --
@@ -156,10 +158,178 @@ getBitsMsm57SatelliteData n = do
 --
 putBitsMsm57SatelliteData :: Msm57SatelliteData -> B.BitPut ()
 putBitsMsm57SatelliteData Msm57SatelliteData {..} = do
-    forM_ _msm57SatelliteData_roughRanges $ B.putWord8 8
-    forM_ _msm57SatelliteData_extendeds $ B.putWord8 4
-    forM_ _msm57SatelliteData_roughRangesModulo $ B.putWord16be 10
-    forM_ _msm57SatelliteData_roughPhaseRangeRates $ B.putWord16be 14
+  forM_ _msm57SatelliteData_roughRanges $ B.putWord8 8
+  forM_ _msm57SatelliteData_extendeds $ B.putWord8 4
+  forM_ _msm57SatelliteData_roughRangesModulo $ B.putWord16be 10
+  forM_ _msm57SatelliteData_roughPhaseRangeRates $ B.putWord16be 14
+
+-- | Msm4SignalData.
+--
+-- MSM4 satellite data.
+data Msm4SignalData = Msm4SignalData
+  { _msm4SignalData_pseudoranges :: [Int16]
+    -- ^ GNSS signal fine pseudoranges.
+  , _msm4SignalData_phaseranges  :: [Int32]
+    -- ^ GNSS signal fine phaserange data.
+  , _msm4SignalData_lockTimes    :: [Word8]
+    -- ^ GNSS phaserange lock time indicators.
+  , _msm4SignalData_halfCycles   :: [Bool]
+    -- ^ Half-cycle ambiguity indicators.
+  , _msm4SignalData_cnrs         :: [Word8]
+    -- ^ GNSS signal CNRs.
+  } deriving ( Show, Read, Eq )
+
+$(makeLenses ''Msm4SignalData)
+$(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msm4SignalData_" . stripPrefix "_msm4SignalData_"} ''Msm4SignalData)
+
+-- | Get Bits for Msm4SignalData.
+--
+getBitsMsm4SignalData :: Int -> B.BitGet Msm4SignalData
+getBitsMsm4SignalData n = do
+  _msm4SignalData_pseudoranges <- replicateM n $ getInt16be 15
+  _msm4SignalData_phaseranges  <- replicateM n $ getInt32be 22
+  _msm4SignalData_lockTimes    <- replicateM n $ B.getWord8 4
+  _msm4SignalData_halfCycles   <- replicateM n B.getBool
+  _msm4SignalData_cnrs         <- replicateM n $ B.getWord8 6
+  pure Msm4SignalData {..}
+
+-- | Put Bits for Msm4SignalData.
+--
+putBitsMsm4SignalData :: Msm4SignalData -> B.BitPut ()
+putBitsMsm4SignalData Msm4SignalData {..} = do
+  forM_ _msm4SignalData_pseudoranges $ putInt16be 15
+  forM_ _msm4SignalData_phaseranges $ putInt32be 22
+  forM_ _msm4SignalData_lockTimes $ B.putWord8 4
+  forM_ _msm4SignalData_halfCycles B.putBool
+  forM_ _msm4SignalData_cnrs $ B.putWord8 6
+
+-- | Msm5SignalData.
+--
+-- MSM5 satellite data.
+data Msm5SignalData = Msm5SignalData
+  { _msm5SignalData_pseudoranges    :: [Int16]
+    -- ^ GNSS signal fine pseudoranges.
+  , _msm5SignalData_phaseranges     :: [Int32]
+    -- ^ GNSS signal fine phaserange data.
+  , _msm5SignalData_lockTimes       :: [Word8]
+    -- ^ GNSS phaserange lock time indicators.
+  , _msm5SignalData_halfCycles      :: [Bool]
+    -- ^ Half-cycle ambiguity indicators.
+  , _msm5SignalData_cnrs            :: [Word8]
+    -- ^ GNSS signal CNRs.
+  , _msm5SignalData_phaseRangeRates :: [Int16]
+    -- ^ GNSS signal fine phaserangerates.
+  } deriving ( Show, Read, Eq )
+
+$(makeLenses ''Msm5SignalData)
+$(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msm5SignalData_" . stripPrefix "_msm5SignalData_"} ''Msm5SignalData)
+
+-- | Get Bits for Msm5SignalData.
+--
+getBitsMsm5SignalData :: Int -> B.BitGet Msm5SignalData
+getBitsMsm5SignalData n = do
+  _msm5SignalData_pseudoranges    <- replicateM n $ getInt16be 15
+  _msm5SignalData_phaseranges     <- replicateM n $ getInt32be 22
+  _msm5SignalData_lockTimes       <- replicateM n $ B.getWord8 4
+  _msm5SignalData_halfCycles      <- replicateM n B.getBool
+  _msm5SignalData_cnrs            <- replicateM n $ B.getWord8 6
+  _msm5SignalData_phaseRangeRates <- replicateM n $ getInt16be 15
+  pure Msm5SignalData {..}
+
+-- | Put Bits for Msm5SignalData.
+--
+putBitsMsm5SignalData :: Msm5SignalData -> B.BitPut ()
+putBitsMsm5SignalData Msm5SignalData {..} = do
+  forM_ _msm5SignalData_pseudoranges $ putInt16be 15
+  forM_ _msm5SignalData_phaseranges $ putInt32be 22
+  forM_ _msm5SignalData_lockTimes $ B.putWord8 4
+  forM_ _msm5SignalData_halfCycles B.putBool
+  forM_ _msm5SignalData_cnrs $ B.putWord8 6
+  forM_ _msm5SignalData_phaseRangeRates $ putInt16be 15
+
+-- | Msm6SignalData.
+--
+-- MSM6 satellite data.
+data Msm6SignalData = Msm6SignalData
+  { _msm6SignalData_pseudoranges :: [Int32]
+    -- ^ GNSS signal fine pseudoranges.
+  , _msm6SignalData_phaseranges  :: [Int32]
+    -- ^ GNSS signal fine phaserange data.
+  , _msm6SignalData_lockTimes    :: [Word16]
+    -- ^ GNSS phaserange lock time indicators.
+  , _msm6SignalData_halfCycles   :: [Bool]
+    -- ^ Half-cycle ambiguity indicators.
+  , _msm6SignalData_cnrs         :: [Word16]
+    -- ^ GNSS signal CNRs.
+  } deriving ( Show, Read, Eq )
+
+$(makeLenses ''Msm6SignalData)
+$(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msm6SignalData_" . stripPrefix "_msm6SignalData_"} ''Msm6SignalData)
+
+-- | Get Bits for Msm6SignalData.
+--
+getBitsMsm6SignalData :: Int -> B.BitGet Msm6SignalData
+getBitsMsm6SignalData n = do
+  _msm6SignalData_pseudoranges <- replicateM n $ getInt32be 20
+  _msm6SignalData_phaseranges  <- replicateM n $ getInt32be 24
+  _msm6SignalData_lockTimes    <- replicateM n $ B.getWord16be 10
+  _msm6SignalData_halfCycles   <- replicateM n B.getBool
+  _msm6SignalData_cnrs         <- replicateM n $ B.getWord16be 10
+  pure Msm6SignalData {..}
+
+-- | Put Bits for Msm6SignalData.
+--
+putBitsMsm6SignalData :: Msm6SignalData -> B.BitPut ()
+putBitsMsm6SignalData Msm6SignalData {..} = do
+  forM_ _msm6SignalData_pseudoranges $ putInt32be 20
+  forM_ _msm6SignalData_phaseranges $ putInt32be 24
+  forM_ _msm6SignalData_lockTimes $ B.putWord16be 10
+  forM_ _msm6SignalData_halfCycles B.putBool
+  forM_ _msm6SignalData_cnrs $ B.putWord16be 10
+
+-- | Msm7SignalData.
+--
+-- MSM7 satellite data.
+data Msm7SignalData = Msm7SignalData
+  { _msm7SignalData_pseudoranges    :: [Int32]
+    -- ^ GNSS signal fine pseudoranges.
+  , _msm7SignalData_phaseranges     :: [Int32]
+    -- ^ GNSS signal fine phaserange data.
+  , _msm7SignalData_lockTimes       :: [Word16]
+    -- ^ GNSS phaserange lock time indicators.
+  , _msm7SignalData_halfCycles      :: [Bool]
+    -- ^ Half-cycle ambiguity indicators.
+  , _msm7SignalData_cnrs            :: [Word16]
+    -- ^ GNSS signal CNRs.
+  , _msm7SignalData_phaseRangeRates :: [Int16]
+    -- ^ GNSS signal fine phaserangerates.
+  } deriving ( Show, Read, Eq )
+
+$(makeLenses ''Msm7SignalData)
+$(deriveJSON defaultOptions {fieldLabelModifier = fromMaybe "_msm7SignalData_" . stripPrefix "_msm7SignalData_"} ''Msm7SignalData)
+
+-- | Get Bits for Msm7SignalData.
+--
+getBitsMsm7SignalData :: Int -> B.BitGet Msm7SignalData
+getBitsMsm7SignalData n = do
+  _msm7SignalData_pseudoranges    <- replicateM n $ getInt32be 20
+  _msm7SignalData_phaseranges     <- replicateM n $ getInt32be 24
+  _msm7SignalData_lockTimes       <- replicateM n $ B.getWord16be 10
+  _msm7SignalData_halfCycles      <- replicateM n B.getBool
+  _msm7SignalData_cnrs            <- replicateM n $ B.getWord16be 10
+  _msm7SignalData_phaseRangeRates <- replicateM n $ getInt16be 15
+  pure Msm7SignalData {..}
+
+-- | Put Bits for Msm7SignalData.
+--
+putBitsMsm7SignalData :: Msm7SignalData -> B.BitPut ()
+putBitsMsm7SignalData Msm7SignalData {..} = do
+  forM_ _msm7SignalData_pseudoranges $ putInt32be 20
+  forM_ _msm7SignalData_phaseranges $ putInt32be 24
+  forM_ _msm7SignalData_lockTimes $ B.putWord16be 10
+  forM_ _msm7SignalData_halfCycles B.putBool
+  forM_ _msm7SignalData_cnrs $ B.putWord16be 10
+  forM_ _msm7SignalData_phaseRangeRates $ putInt16be 15
 
 msg1074 :: Word16
 msg1074 = 1074
@@ -175,6 +345,8 @@ data Msg1074 = Msg1074
     -- ^ MSM header.
   , _msg1074_satelliteData :: Msm46SatelliteData
     -- ^ MSM satellite data.
+  , _msg1074_signalData    :: Msm4SignalData
+    -- ^ MSM signal data.
   } deriving ( Show, Read, Eq )
 
 $(makeLenses ''Msg1074)
@@ -184,11 +356,13 @@ instance Binary Msg1074 where
   get = B.runBitGet $ do
     _msg1074_header        <- getBits 0
     _msg1074_satelliteData <- getBitsMsm46SatelliteData $ popCount $ _msg1074_header ^. msmHeader_satelliteMask
+    _msg1074_signalData    <- getBitsMsm4SignalData $ popCount $ _msg1074_header ^. msmHeader_cellMask
     pure Msg1074 {..}
 
   put Msg1074 {..} = B.runBitPut $ do
     putBits 0                 _msg1074_header
     putBitsMsm46SatelliteData _msg1074_satelliteData
+    putBitsMsm4SignalData     _msg1074_signalData
 
 $(deriveRTCM3 ''Msg1074)
 
@@ -206,6 +380,8 @@ data Msg1075 = Msg1075
     -- ^ MSM header.
   , _msg1075_satelliteData :: Msm57SatelliteData
     -- ^ MSM satellite data.
+  , _msg1075_signalData    :: Msm5SignalData
+    -- ^ MSM signal data.
   } deriving ( Show, Read, Eq )
 
 $(makeLenses ''Msg1075)
@@ -215,11 +391,13 @@ instance Binary Msg1075 where
   get = B.runBitGet $ do
     _msg1075_header        <- getBits 0
     _msg1075_satelliteData <- getBitsMsm57SatelliteData $ popCount $ _msg1075_header ^. msmHeader_satelliteMask
+    _msg1075_signalData    <- getBitsMsm5SignalData $ popCount $ _msg1075_header ^. msmHeader_cellMask
     pure Msg1075 {..}
 
   put Msg1075 {..} = B.runBitPut $ do
     putBits 0                 _msg1075_header
     putBitsMsm57SatelliteData _msg1075_satelliteData
+    putBitsMsm5SignalData     _msg1075_signalData
 
 $(deriveRTCM3 ''Msg1075)
 
@@ -237,6 +415,8 @@ data Msg1076 = Msg1076
     -- ^ MSM header.
   , _msg1076_satelliteData :: Msm46SatelliteData
     -- ^ MSM satellite data.
+  , _msg1076_signalData    :: Msm6SignalData
+    -- ^ MSM signal data.
   } deriving ( Show, Read, Eq )
 
 $(makeLenses ''Msg1076)
@@ -246,11 +426,13 @@ instance Binary Msg1076 where
   get = B.runBitGet $ do
     _msg1076_header        <- getBits 0
     _msg1076_satelliteData <- getBitsMsm46SatelliteData $ popCount $ _msg1076_header ^. msmHeader_satelliteMask
+    _msg1076_signalData    <- getBitsMsm6SignalData $ popCount $ _msg1076_header ^. msmHeader_cellMask
     pure Msg1076 {..}
 
   put Msg1076 {..} = B.runBitPut $ do
     putBits 0                 _msg1076_header
     putBitsMsm46SatelliteData _msg1076_satelliteData
+    putBitsMsm6SignalData     _msg1076_signalData
 
 $(deriveRTCM3 ''Msg1076)
 
@@ -268,6 +450,8 @@ data Msg1077 = Msg1077
     -- ^ MSM header.
   , _msg1077_satelliteData :: Msm57SatelliteData
     -- ^ MSM satellite data.
+  , _msg1077_signalData    :: Msm7SignalData
+    -- ^ MSM signal data.
   } deriving ( Show, Read, Eq )
 
 $(makeLenses ''Msg1077)
@@ -277,11 +461,13 @@ instance Binary Msg1077 where
   get = B.runBitGet $ do
     _msg1077_header        <- getBits 0
     _msg1077_satelliteData <- getBitsMsm57SatelliteData $ popCount $ _msg1077_header ^. msmHeader_satelliteMask
+    _msg1077_signalData    <- getBitsMsm7SignalData $ popCount $ _msg1077_header ^. msmHeader_cellMask
     pure Msg1077 {..}
 
   put Msg1077 {..} = B.runBitPut $ do
     putBits 0                 _msg1077_header
     putBitsMsm57SatelliteData _msg1077_satelliteData
+    putBitsMsm7SignalData     _msg1077_signalData
 
 $(deriveRTCM3 ''Msg1077)
 
@@ -299,6 +485,8 @@ data Msg1084 = Msg1084
     -- ^ MSM header.
   , _msg1084_satelliteData :: Msm46SatelliteData
     -- ^ MSM satellite data.
+  , _msg1084_signalData    :: Msm4SignalData
+    -- ^ MSM satellite data.
   } deriving ( Show, Read, Eq )
 
 $(makeLenses ''Msg1084)
@@ -308,11 +496,13 @@ instance Binary Msg1084 where
   get = B.runBitGet $ do
     _msg1084_header        <- getBits 0
     _msg1084_satelliteData <- getBitsMsm46SatelliteData $ popCount $ _msg1084_header ^. msmHeader_satelliteMask
+    _msg1084_signalData    <- getBitsMsm4SignalData $ popCount $ _msg1084_header ^. msmHeader_cellMask
     pure Msg1084 {..}
 
   put Msg1084 {..} = B.runBitPut $ do
     putBits 0                 _msg1084_header
     putBitsMsm46SatelliteData _msg1084_satelliteData
+    putBitsMsm4SignalData     _msg1084_signalData
 
 $(deriveRTCM3 ''Msg1084)
 
@@ -330,6 +520,8 @@ data Msg1085 = Msg1085
     -- ^ MSM header.
   , _msg1085_satelliteData :: Msm57SatelliteData
     -- ^ MSM satellite data.
+  , _msg1085_signalData    :: Msm5SignalData
+    -- ^ MSM signal data.
   } deriving ( Show, Read, Eq )
 
 $(makeLenses ''Msg1085)
@@ -339,11 +531,13 @@ instance Binary Msg1085 where
   get = B.runBitGet $ do
     _msg1085_header <- getBits 0
     _msg1085_satelliteData <- getBitsMsm57SatelliteData $ popCount $ _msg1085_header ^. msmHeader_satelliteMask
+    _msg1085_signalData    <- getBitsMsm5SignalData $ popCount $ _msg1085_header ^. msmHeader_cellMask
     pure Msg1085 {..}
 
   put Msg1085 {..} = B.runBitPut $ do
     putBits 0                 _msg1085_header
     putBitsMsm57SatelliteData _msg1085_satelliteData
+    putBitsMsm5SignalData     _msg1085_signalData
 
 $(deriveRTCM3 ''Msg1085)
 
@@ -361,6 +555,8 @@ data Msg1086 = Msg1086
     -- ^ MSM header.
   , _msg1086_satelliteData :: Msm46SatelliteData
     -- ^ MSM satellite data.
+  , _msg1086_signalData    :: Msm6SignalData
+    -- ^ MSM signal data.
   } deriving ( Show, Read, Eq )
 
 $(makeLenses ''Msg1086)
@@ -370,11 +566,13 @@ instance Binary Msg1086 where
   get = B.runBitGet $ do
     _msg1086_header        <- getBits 0
     _msg1086_satelliteData <- getBitsMsm46SatelliteData $ popCount $ _msg1086_header ^. msmHeader_satelliteMask
+    _msg1086_signalData    <- getBitsMsm6SignalData $ popCount $ _msg1086_header ^. msmHeader_cellMask
     pure Msg1086 {..}
 
   put Msg1086 {..} = B.runBitPut $ do
     putBits 0                 _msg1086_header
     putBitsMsm46SatelliteData _msg1086_satelliteData
+    putBitsMsm6SignalData     _msg1086_signalData
 
 $(deriveRTCM3 ''Msg1086)
 
@@ -392,6 +590,8 @@ data Msg1087 = Msg1087
     -- ^ MSM header.
   , _msg1087_satelliteData :: Msm57SatelliteData
     -- ^ MSM satellite data.
+  , _msg1087_signalData    :: Msm7SignalData
+    -- ^ MSM signal data.
   } deriving ( Show, Read, Eq )
 
 $(makeLenses ''Msg1087)
@@ -401,11 +601,13 @@ instance Binary Msg1087 where
   get = B.runBitGet $ do
     _msg1087_header        <- getBits 0
     _msg1087_satelliteData <- getBitsMsm57SatelliteData $ popCount $ _msg1087_header ^. msmHeader_satelliteMask
+    _msg1087_signalData    <- getBitsMsm7SignalData $ popCount $ _msg1087_header ^. msmHeader_cellMask
     pure Msg1087 {..}
 
   put Msg1087 {..} = B.runBitPut $ do
     putBits 0                 _msg1087_header
     putBitsMsm57SatelliteData _msg1087_satelliteData
+    putBitsMsm7SignalData     _msg1087_signalData
 
 $(deriveRTCM3 ''Msg1087)
 
@@ -423,6 +625,8 @@ data Msg1094 = Msg1094
     -- ^ MSM header.
   , _msg1094_satelliteData :: Msm46SatelliteData
     -- ^ MSM satellite data.
+  , _msg1094_signalData    :: Msm4SignalData
+    -- ^ MSM satellite data.
   } deriving ( Show, Read, Eq )
 
 $(makeLenses ''Msg1094)
@@ -432,11 +636,13 @@ instance Binary Msg1094 where
   get = B.runBitGet $ do
     _msg1094_header        <- getBits 0
     _msg1094_satelliteData <- getBitsMsm46SatelliteData $ popCount $ _msg1094_header ^. msmHeader_satelliteMask
+    _msg1094_signalData    <- getBitsMsm4SignalData $ popCount $ _msg1094_header ^. msmHeader_cellMask
     pure Msg1094 {..}
 
   put Msg1094 {..} = B.runBitPut $ do
     putBits 0                 _msg1094_header
     putBitsMsm46SatelliteData _msg1094_satelliteData
+    putBitsMsm4SignalData     _msg1094_signalData
 
 $(deriveRTCM3 ''Msg1094)
 
@@ -454,6 +660,8 @@ data Msg1095 = Msg1095
     -- ^ MSM header.
   , _msg1095_satelliteData :: Msm57SatelliteData
     -- ^ MSM satellite data.
+  , _msg1095_signalData    :: Msm5SignalData
+    -- ^ MSM signal data.
   } deriving ( Show, Read, Eq )
 
 $(makeLenses ''Msg1095)
@@ -463,11 +671,13 @@ instance Binary Msg1095 where
   get = B.runBitGet $ do
     _msg1095_header        <- getBits 0
     _msg1095_satelliteData <- getBitsMsm57SatelliteData $ popCount $ _msg1095_header ^. msmHeader_satelliteMask
+    _msg1095_signalData    <- getBitsMsm5SignalData $ popCount $ _msg1095_header ^. msmHeader_cellMask
     pure Msg1095 {..}
 
   put Msg1095 {..} = B.runBitPut $ do
     putBits 0                 _msg1095_header
     putBitsMsm57SatelliteData _msg1095_satelliteData
+    putBitsMsm5SignalData     _msg1095_signalData
 
 $(deriveRTCM3 ''Msg1095)
 
@@ -485,6 +695,8 @@ data Msg1096 = Msg1096
     -- ^ MSM header.
   , _msg1096_satelliteData :: Msm46SatelliteData
     -- ^ MSM satellite data.
+  , _msg1096_signalData    :: Msm6SignalData
+    -- ^ MSM signal data.
   } deriving ( Show, Read, Eq )
 
 $(makeLenses ''Msg1096)
@@ -494,11 +706,13 @@ instance Binary Msg1096 where
   get = B.runBitGet $ do
     _msg1096_header        <- getBits 0
     _msg1096_satelliteData <- getBitsMsm46SatelliteData $ popCount $ _msg1096_header ^. msmHeader_satelliteMask
+    _msg1096_signalData    <- getBitsMsm6SignalData $ popCount $ _msg1096_header ^. msmHeader_cellMask
     pure Msg1096 {..}
 
   put Msg1096 {..} = B.runBitPut $ do
     putBits 0                 _msg1096_header
     putBitsMsm46SatelliteData _msg1096_satelliteData
+    putBitsMsm6SignalData     _msg1096_signalData
 
 $(deriveRTCM3 ''Msg1096)
 
@@ -516,6 +730,8 @@ data Msg1097 = Msg1097
     -- ^ MSM header.
   , _msg1097_satelliteData :: Msm57SatelliteData
     -- ^ MSM satellite data.
+  , _msg1097_signalData    :: Msm7SignalData
+    -- ^ MSM signal data.
   } deriving ( Show, Read, Eq )
 
 $(makeLenses ''Msg1097)
@@ -525,11 +741,13 @@ instance Binary Msg1097 where
   get = B.runBitGet $ do
     _msg1097_header        <- getBits 0
     _msg1097_satelliteData <- getBitsMsm57SatelliteData $ popCount $ _msg1097_header ^. msmHeader_satelliteMask
+    _msg1097_signalData    <- getBitsMsm7SignalData $ popCount $ _msg1097_header ^. msmHeader_cellMask
     pure Msg1097 {..}
 
   put Msg1097 {..} = B.runBitPut $ do
     putBits 0                 _msg1097_header
     putBitsMsm57SatelliteData _msg1097_satelliteData
+    putBitsMsm7SignalData     _msg1097_signalData
 
 $(deriveRTCM3 ''Msg1097)
 
@@ -547,6 +765,8 @@ data Msg1104 = Msg1104
     -- ^ MSM header.
   , _msg1104_satelliteData :: Msm46SatelliteData
     -- ^ MSM satellite data.
+  , _msg1104_signalData    :: Msm4SignalData
+    -- ^ MSM satellite data.
   } deriving ( Show, Read, Eq )
 
 $(makeLenses ''Msg1104)
@@ -556,11 +776,13 @@ instance Binary Msg1104 where
   get = B.runBitGet $ do
     _msg1104_header        <- getBits 0
     _msg1104_satelliteData <- getBitsMsm46SatelliteData $ popCount $ _msg1104_header ^. msmHeader_satelliteMask
+    _msg1104_signalData    <- getBitsMsm4SignalData $ popCount $ _msg1104_header ^. msmHeader_cellMask
     pure Msg1104 {..}
 
   put Msg1104 {..} = B.runBitPut $ do
     putBits 0                 _msg1104_header
     putBitsMsm46SatelliteData _msg1104_satelliteData
+    putBitsMsm4SignalData     _msg1104_signalData
 
 $(deriveRTCM3 ''Msg1104)
 
@@ -578,6 +800,8 @@ data Msg1105 = Msg1105
     -- ^ MSM header.
   , _msg1105_satelliteData :: Msm57SatelliteData
     -- ^ MSM satellite data.
+  , _msg1105_signalData    :: Msm5SignalData
+    -- ^ MSM signal data.
   } deriving ( Show, Read, Eq )
 
 $(makeLenses ''Msg1105)
@@ -587,11 +811,13 @@ instance Binary Msg1105 where
   get = B.runBitGet $ do
     _msg1105_header        <- getBits 0
     _msg1105_satelliteData <- getBitsMsm57SatelliteData $ popCount $ _msg1105_header ^. msmHeader_satelliteMask
+    _msg1105_signalData    <- getBitsMsm5SignalData $ popCount $ _msg1105_header ^. msmHeader_cellMask
     pure Msg1105 {..}
 
   put Msg1105 {..} = B.runBitPut $ do
     putBits 0                 _msg1105_header
     putBitsMsm57SatelliteData _msg1105_satelliteData
+    putBitsMsm5SignalData     _msg1105_signalData
 
 $(deriveRTCM3 ''Msg1105)
 
@@ -609,6 +835,8 @@ data Msg1106 = Msg1106
     -- ^ MSM header.
   , _msg1106_satelliteData :: Msm46SatelliteData
     -- ^ MSM satellite data.
+  , _msg1106_signalData    :: Msm6SignalData
+    -- ^ MSM signal data.
   } deriving ( Show, Read, Eq )
 
 $(makeLenses ''Msg1106)
@@ -618,11 +846,13 @@ instance Binary Msg1106 where
   get = B.runBitGet $ do
     _msg1106_header        <- getBits 0
     _msg1106_satelliteData <- getBitsMsm46SatelliteData $ popCount $ _msg1106_header ^. msmHeader_satelliteMask
+    _msg1106_signalData    <- getBitsMsm6SignalData $ popCount $ _msg1106_header ^. msmHeader_cellMask
     pure Msg1106 {..}
 
   put Msg1106 {..} = B.runBitPut $ do
     putBits 0                 _msg1106_header
     putBitsMsm46SatelliteData _msg1106_satelliteData
+    putBitsMsm6SignalData     _msg1106_signalData
 
 $(deriveRTCM3 ''Msg1106)
 
@@ -640,6 +870,8 @@ data Msg1107 = Msg1107
     -- ^ MSM header.
   , _msg1107_satelliteData :: Msm57SatelliteData
     -- ^ MSM satellite data.
+  , _msg1107_signalData    :: Msm7SignalData
+    -- ^ MSM signal data.
   } deriving ( Show, Read, Eq )
 
 $(makeLenses ''Msg1107)
@@ -649,11 +881,13 @@ instance Binary Msg1107 where
   get = B.runBitGet $ do
     _msg1107_header        <- getBits 0
     _msg1107_satelliteData <- getBitsMsm57SatelliteData $ popCount $ _msg1107_header ^. msmHeader_satelliteMask
+    _msg1107_signalData    <- getBitsMsm7SignalData $ popCount $ _msg1107_header ^. msmHeader_cellMask
     pure Msg1107 {..}
 
   put Msg1107 {..} = B.runBitPut $ do
     putBits 0                 _msg1107_header
     putBitsMsm57SatelliteData _msg1107_satelliteData
+    putBitsMsm7SignalData     _msg1107_signalData
 
 $(deriveRTCM3 ''Msg1107)
 
@@ -671,6 +905,8 @@ data Msg1114 = Msg1114
     -- ^ MSM header.
   , _msg1114_satelliteData :: Msm46SatelliteData
     -- ^ MSM satellite data.
+  , _msg1114_signalData    :: Msm4SignalData
+    -- ^ MSM satellite data.
   } deriving ( Show, Read, Eq )
 
 $(makeLenses ''Msg1114)
@@ -680,11 +916,13 @@ instance Binary Msg1114 where
   get = B.runBitGet $ do
     _msg1114_header        <- getBits 0
     _msg1114_satelliteData <- getBitsMsm46SatelliteData $ popCount $ _msg1114_header ^. msmHeader_satelliteMask
+    _msg1114_signalData    <- getBitsMsm4SignalData $ popCount $ _msg1114_header ^. msmHeader_cellMask
     pure Msg1114 {..}
 
   put Msg1114 {..} = B.runBitPut $ do
     putBits 0                 _msg1114_header
     putBitsMsm46SatelliteData _msg1114_satelliteData
+    putBitsMsm4SignalData     _msg1114_signalData
 
 $(deriveRTCM3 ''Msg1114)
 
@@ -702,6 +940,8 @@ data Msg1115 = Msg1115
     -- ^ MSM header.
   , _msg1115_satelliteData :: Msm57SatelliteData
     -- ^ MSM satellite data.
+  , _msg1115_signalData    :: Msm5SignalData
+    -- ^ MSM signal data.
   } deriving ( Show, Read, Eq )
 
 $(makeLenses ''Msg1115)
@@ -711,11 +951,13 @@ instance Binary Msg1115 where
   get = B.runBitGet $ do
     _msg1115_header        <- getBits 0
     _msg1115_satelliteData <- getBitsMsm57SatelliteData $ popCount $ _msg1115_header ^. msmHeader_satelliteMask
+    _msg1115_signalData    <- getBitsMsm5SignalData $ popCount $ _msg1115_header ^. msmHeader_cellMask
     pure Msg1115 {..}
 
   put Msg1115 {..} = B.runBitPut $ do
     putBits 0                 _msg1115_header
     putBitsMsm57SatelliteData _msg1115_satelliteData
+    putBitsMsm5SignalData     _msg1115_signalData
 
 $(deriveRTCM3 ''Msg1115)
 
@@ -733,6 +975,8 @@ data Msg1116 = Msg1116
     -- ^ MSM header.
   , _msg1116_satelliteData :: Msm46SatelliteData
     -- ^ MSM satellite data.
+  , _msg1116_signalData    :: Msm6SignalData
+    -- ^ MSM signal data.
   } deriving ( Show, Read, Eq )
 
 $(makeLenses ''Msg1116)
@@ -742,11 +986,13 @@ instance Binary Msg1116 where
   get = B.runBitGet $ do
     _msg1116_header        <- getBits 0
     _msg1116_satelliteData <- getBitsMsm46SatelliteData $ popCount $ _msg1116_header ^. msmHeader_satelliteMask
+    _msg1116_signalData    <- getBitsMsm6SignalData $ popCount $ _msg1116_header ^. msmHeader_cellMask
     pure Msg1116 {..}
 
   put Msg1116 {..} = B.runBitPut $ do
     putBits 0                 _msg1116_header
     putBitsMsm46SatelliteData _msg1116_satelliteData
+    putBitsMsm6SignalData     _msg1116_signalData
 
 $(deriveRTCM3 ''Msg1116)
 
@@ -764,6 +1010,8 @@ data Msg1117 = Msg1117
     -- ^ MSM header.
   , _msg1117_satelliteData :: Msm57SatelliteData
     -- ^ MSM satellite data.
+  , _msg1117_signalData    :: Msm7SignalData
+    -- ^ MSM signal data.
   } deriving ( Show, Read, Eq )
 
 $(makeLenses ''Msg1117)
@@ -773,11 +1021,13 @@ instance Binary Msg1117 where
   get = B.runBitGet $ do
     _msg1117_header        <- getBits 0
     _msg1117_satelliteData <- getBitsMsm57SatelliteData $ popCount $ _msg1117_header ^. msmHeader_satelliteMask
+    _msg1117_signalData    <- getBitsMsm7SignalData $ popCount $ _msg1117_header ^. msmHeader_cellMask
     pure Msg1117 {..}
 
   put Msg1117 {..} = B.runBitPut $ do
     putBits 0                 _msg1117_header
     putBitsMsm57SatelliteData _msg1117_satelliteData
+    putBitsMsm7SignalData     _msg1117_signalData
 
 $(deriveRTCM3 ''Msg1117)
 
@@ -795,6 +1045,8 @@ data Msg1124 = Msg1124
     -- ^ MSM header.
   , _msg1124_satelliteData :: Msm46SatelliteData
     -- ^ MSM satellite data.
+  , _msg1124_signalData    :: Msm4SignalData
+    -- ^ MSM satellite data.
   } deriving ( Show, Read, Eq )
 
 $(makeLenses ''Msg1124)
@@ -804,11 +1056,13 @@ instance Binary Msg1124 where
   get = B.runBitGet $ do
     _msg1124_header        <- getBits 0
     _msg1124_satelliteData <- getBitsMsm46SatelliteData $ popCount $ _msg1124_header ^. msmHeader_satelliteMask
+    _msg1124_signalData    <- getBitsMsm4SignalData $ popCount $ _msg1124_header ^. msmHeader_cellMask
     pure Msg1124 {..}
 
   put Msg1124 {..} = B.runBitPut $ do
     putBits 0                 _msg1124_header
     putBitsMsm46SatelliteData _msg1124_satelliteData
+    putBitsMsm4SignalData     _msg1124_signalData
 
 $(deriveRTCM3 ''Msg1124)
 
@@ -826,6 +1080,8 @@ data Msg1125 = Msg1125
     -- ^ MSM header.
   , _msg1125_satelliteData :: Msm57SatelliteData
     -- ^ MSM satellite data.
+  , _msg1125_signalData    :: Msm5SignalData
+    -- ^ MSM signal data.
   } deriving ( Show, Read, Eq )
 
 $(makeLenses ''Msg1125)
@@ -835,11 +1091,13 @@ instance Binary Msg1125 where
   get = B.runBitGet $ do
     _msg1125_header        <- getBits 0
     _msg1125_satelliteData <- getBitsMsm57SatelliteData $ popCount $ _msg1125_header ^. msmHeader_satelliteMask
+    _msg1125_signalData    <- getBitsMsm5SignalData $ popCount $ _msg1125_header ^. msmHeader_cellMask
     pure Msg1125 {..}
 
   put Msg1125 {..} = B.runBitPut $ do
     putBits 0                 _msg1125_header
     putBitsMsm57SatelliteData _msg1125_satelliteData
+    putBitsMsm5SignalData     _msg1125_signalData
 
 $(deriveRTCM3 ''Msg1125)
 
@@ -857,6 +1115,8 @@ data Msg1126 = Msg1126
     -- ^ MSM header.
   , _msg1126_satelliteData :: Msm46SatelliteData
     -- ^ MSM satellite data.
+  , _msg1126_signalData    :: Msm6SignalData
+    -- ^ MSM signal data.
   } deriving ( Show, Read, Eq )
 
 $(makeLenses ''Msg1126)
@@ -866,11 +1126,13 @@ instance Binary Msg1126 where
   get = B.runBitGet $ do
     _msg1126_header        <- getBits 0
     _msg1126_satelliteData <- getBitsMsm46SatelliteData $ popCount $ _msg1126_header ^. msmHeader_satelliteMask
+    _msg1126_signalData    <- getBitsMsm6SignalData $ popCount $ _msg1126_header ^. msmHeader_cellMask
     pure Msg1126 {..}
 
   put Msg1126 {..} = B.runBitPut $ do
     putBits 0                 _msg1126_header
     putBitsMsm46SatelliteData _msg1126_satelliteData
+    putBitsMsm6SignalData     _msg1126_signalData
 
 $(deriveRTCM3 ''Msg1126)
 
@@ -888,6 +1150,8 @@ data Msg1127 = Msg1127
     -- ^ MSM header.
   , _msg1127_satelliteData :: Msm57SatelliteData
     -- ^ MSM satellite data.
+  , _msg1127_signalData    :: Msm7SignalData
+    -- ^ MSM signal data.
   } deriving ( Show, Read, Eq )
 
 $(makeLenses ''Msg1127)
@@ -897,11 +1161,13 @@ instance Binary Msg1127 where
   get = B.runBitGet $ do
     _msg1127_header        <- getBits 0
     _msg1127_satelliteData <- getBitsMsm57SatelliteData $ popCount $ _msg1127_header ^. msmHeader_satelliteMask
+    _msg1127_signalData    <- getBitsMsm7SignalData $ popCount $ _msg1127_header ^. msmHeader_cellMask
     pure Msg1127 {..}
 
   put Msg1127 {..} = B.runBitPut $ do
     putBits 0                 _msg1127_header
     putBitsMsm57SatelliteData _msg1127_satelliteData
+    putBitsMsm7SignalData     _msg1127_signalData
 
 $(deriveRTCM3 ''Msg1127)
 

--- a/haskell/test/Test.hs
+++ b/haskell/test/Test.hs
@@ -13,6 +13,7 @@ import qualified Test.Data.CRC24Q             as CRC24Q
 import qualified Test.Data.RTCM3.Antennas     as Antennas
 import qualified Test.Data.RTCM3.Ephemerides  as Ephemerides
 import qualified Test.Data.RTCM3.Extras       as Extras
+import qualified Test.Data.RTCM3.MSM          as MSM
 import qualified Test.Data.RTCM3.Observations as Observations
 import qualified Test.Data.RTCM3.SSR          as SSR
 import qualified Test.Data.RTCM3.System       as System
@@ -25,6 +26,7 @@ tests =
     , Antennas.tests
     , Ephemerides.tests
     , Extras.tests
+    , MSM.tests
     , Observations.tests
     , SSR.tests
     , System.tests

--- a/haskell/test/Test/Data/RTCM3/MSM.hs
+++ b/haskell/test/Test/Data/RTCM3/MSM.hs
@@ -55,148 +55,210 @@ arbitraryMsm57SatelliteData n = do
   _msm57SatelliteData_roughPhaseRangeRates <- replicateM n $ arbitraryWord 14
   pure Msm57SatelliteData {..}
 
+arbitraryMsm4SignalData :: Int -> Gen Msm4SignalData
+arbitraryMsm4SignalData n = do
+  _msm4SignalData_pseudoranges <- replicateM n $ arbitraryInt 15
+  _msm4SignalData_phaseranges  <- replicateM n $ arbitraryInt 22
+  _msm4SignalData_lockTimes    <- replicateM n $ arbitraryWord 4
+  _msm4SignalData_halfCycles   <- replicateM n arbitrary
+  _msm4SignalData_cnrs         <- replicateM n $ arbitraryWord 6
+  pure Msm4SignalData {..}
+
+arbitraryMsm5SignalData :: Int -> Gen Msm5SignalData
+arbitraryMsm5SignalData n = do
+  _msm5SignalData_pseudoranges    <- replicateM n $ arbitraryInt 15
+  _msm5SignalData_phaseranges     <- replicateM n $ arbitraryInt 22
+  _msm5SignalData_lockTimes       <- replicateM n $ arbitraryWord 4
+  _msm5SignalData_halfCycles      <- replicateM n arbitrary
+  _msm5SignalData_cnrs            <- replicateM n $ arbitraryWord 6
+  _msm5SignalData_phaseRangeRates <- replicateM n $ arbitraryInt 15
+  pure Msm5SignalData {..}
+
+arbitraryMsm6SignalData :: Int -> Gen Msm6SignalData
+arbitraryMsm6SignalData n = do
+  _msm6SignalData_pseudoranges <- replicateM n $ arbitraryInt 20
+  _msm6SignalData_phaseranges  <- replicateM n $ arbitraryInt 24
+  _msm6SignalData_lockTimes    <- replicateM n $ arbitraryWord 10
+  _msm6SignalData_halfCycles   <- replicateM n arbitrary
+  _msm6SignalData_cnrs         <- replicateM n $ arbitraryWord 10
+  pure Msm6SignalData {..}
+
+arbitraryMsm7SignalData :: Int -> Gen Msm7SignalData
+arbitraryMsm7SignalData n = do
+  _msm7SignalData_pseudoranges    <- replicateM n $ arbitraryInt 20
+  _msm7SignalData_phaseranges     <- replicateM n $ arbitraryInt 24
+  _msm7SignalData_lockTimes       <- replicateM n $ arbitraryWord 10
+  _msm7SignalData_halfCycles      <- replicateM n arbitrary
+  _msm7SignalData_cnrs            <- replicateM n $ arbitraryWord 10
+  _msm7SignalData_phaseRangeRates <- replicateM n $ arbitraryInt 15
+  pure Msm7SignalData {..}
+
 instance Arbitrary Msg1074 where
   arbitrary = do
     _msg1074_header        <- arbitrary
     _msg1074_satelliteData <- arbitraryMsm46SatelliteData $ popCount $ _msg1074_header ^. msmHeader_satelliteMask
+    _msg1074_signalData    <- arbitraryMsm4SignalData $ popCount $ _msg1074_header ^. msmHeader_cellMask
     pure Msg1074 {..}
 
 instance Arbitrary Msg1075 where
   arbitrary = do
     _msg1075_header        <- arbitrary
     _msg1075_satelliteData <- arbitraryMsm57SatelliteData $ popCount $ _msg1075_header ^. msmHeader_satelliteMask
+    _msg1075_signalData    <- arbitraryMsm5SignalData $ popCount $ _msg1075_header ^. msmHeader_cellMask
     pure Msg1075 {..}
 
 instance Arbitrary Msg1076 where
   arbitrary = do
     _msg1076_header        <- arbitrary
     _msg1076_satelliteData <- arbitraryMsm46SatelliteData $ popCount $ _msg1076_header ^. msmHeader_satelliteMask
+    _msg1076_signalData    <- arbitraryMsm6SignalData $ popCount $ _msg1076_header ^. msmHeader_cellMask
     pure Msg1076 {..}
 
 instance Arbitrary Msg1077 where
   arbitrary = do
     _msg1077_header        <- arbitrary
     _msg1077_satelliteData <- arbitraryMsm57SatelliteData $ popCount $ _msg1077_header ^. msmHeader_satelliteMask
+    _msg1077_signalData    <- arbitraryMsm7SignalData $ popCount $ _msg1077_header ^. msmHeader_cellMask
     pure Msg1077 {..}
 
 instance Arbitrary Msg1084 where
   arbitrary = do
-    _msg1084_header <- arbitrary
+    _msg1084_header        <- arbitrary
     _msg1084_satelliteData <- arbitraryMsm46SatelliteData $ popCount $ _msg1084_header ^. msmHeader_satelliteMask
+    _msg1084_signalData    <- arbitraryMsm4SignalData $ popCount $ _msg1084_header ^. msmHeader_cellMask
     pure Msg1084 {..}
 
 instance Arbitrary Msg1085 where
   arbitrary = do
     _msg1085_header        <- arbitrary
     _msg1085_satelliteData <- arbitraryMsm57SatelliteData $ popCount $ _msg1085_header ^. msmHeader_satelliteMask
+    _msg1085_signalData    <- arbitraryMsm5SignalData $ popCount $ _msg1085_header ^. msmHeader_cellMask
     pure Msg1085 {..}
 
 instance Arbitrary Msg1086 where
   arbitrary = do
     _msg1086_header        <- arbitrary
     _msg1086_satelliteData <- arbitraryMsm46SatelliteData $ popCount $ _msg1086_header ^. msmHeader_satelliteMask
+    _msg1086_signalData    <- arbitraryMsm6SignalData $ popCount $ _msg1086_header ^. msmHeader_cellMask
     pure Msg1086 {..}
 
 instance Arbitrary Msg1087 where
   arbitrary = do
     _msg1087_header        <- arbitrary
     _msg1087_satelliteData <- arbitraryMsm57SatelliteData $ popCount $ _msg1087_header ^. msmHeader_satelliteMask
+    _msg1087_signalData    <- arbitraryMsm7SignalData $ popCount $ _msg1087_header ^. msmHeader_cellMask
     pure Msg1087 {..}
 
 instance Arbitrary Msg1094 where
   arbitrary = do
     _msg1094_header        <- arbitrary
     _msg1094_satelliteData <- arbitraryMsm46SatelliteData $ popCount $ _msg1094_header ^. msmHeader_satelliteMask
+    _msg1094_signalData    <- arbitraryMsm4SignalData $ popCount $ _msg1094_header ^. msmHeader_cellMask
     pure Msg1094 {..}
 
 instance Arbitrary Msg1095 where
   arbitrary = do
     _msg1095_header        <- arbitrary
     _msg1095_satelliteData <- arbitraryMsm57SatelliteData $ popCount $ _msg1095_header ^. msmHeader_satelliteMask
+    _msg1095_signalData    <- arbitraryMsm5SignalData $ popCount $ _msg1095_header ^. msmHeader_cellMask
     pure Msg1095 {..}
 
 instance Arbitrary Msg1096 where
   arbitrary = do
     _msg1096_header        <- arbitrary
     _msg1096_satelliteData <- arbitraryMsm46SatelliteData $ popCount $ _msg1096_header ^. msmHeader_satelliteMask
+    _msg1096_signalData    <- arbitraryMsm6SignalData $ popCount $ _msg1096_header ^. msmHeader_cellMask
     pure Msg1096 {..}
 
 instance Arbitrary Msg1097 where
   arbitrary = do
     _msg1097_header        <- arbitrary
     _msg1097_satelliteData <- arbitraryMsm57SatelliteData $ popCount $ _msg1097_header ^. msmHeader_satelliteMask
+    _msg1097_signalData    <- arbitraryMsm7SignalData $ popCount $ _msg1097_header ^. msmHeader_cellMask
     pure Msg1097 {..}
 
 instance Arbitrary Msg1104 where
   arbitrary = do
     _msg1104_header        <- arbitrary
     _msg1104_satelliteData <- arbitraryMsm46SatelliteData $ popCount $ _msg1104_header ^. msmHeader_satelliteMask
+    _msg1104_signalData    <- arbitraryMsm4SignalData $ popCount $ _msg1104_header ^. msmHeader_cellMask
     pure Msg1104 {..}
 
 instance Arbitrary Msg1105 where
   arbitrary = do
     _msg1105_header        <- arbitrary
     _msg1105_satelliteData <- arbitraryMsm57SatelliteData $ popCount $ _msg1105_header ^. msmHeader_satelliteMask
+    _msg1105_signalData    <- arbitraryMsm5SignalData $ popCount $ _msg1105_header ^. msmHeader_cellMask
     pure Msg1105 {..}
 
 instance Arbitrary Msg1106 where
   arbitrary = do
     _msg1106_header        <- arbitrary
     _msg1106_satelliteData <- arbitraryMsm46SatelliteData $ popCount $ _msg1106_header ^. msmHeader_satelliteMask
+    _msg1106_signalData    <- arbitraryMsm6SignalData $ popCount $ _msg1106_header ^. msmHeader_cellMask
     pure Msg1106 {..}
 
 instance Arbitrary Msg1107 where
   arbitrary = do
     _msg1107_header        <- arbitrary
     _msg1107_satelliteData <- arbitraryMsm57SatelliteData $ popCount $ _msg1107_header ^. msmHeader_satelliteMask
+    _msg1107_signalData    <- arbitraryMsm7SignalData $ popCount $ _msg1107_header ^. msmHeader_cellMask
     pure Msg1107 {..}
 
 instance Arbitrary Msg1114 where
   arbitrary = do
     _msg1114_header        <- arbitrary
     _msg1114_satelliteData <- arbitraryMsm46SatelliteData $ popCount $ _msg1114_header ^. msmHeader_satelliteMask
+    _msg1114_signalData    <- arbitraryMsm4SignalData $ popCount $ _msg1114_header ^. msmHeader_cellMask
     pure Msg1114 {..}
 
 instance Arbitrary Msg1115 where
   arbitrary = do
     _msg1115_header        <- arbitrary
     _msg1115_satelliteData <- arbitraryMsm57SatelliteData $ popCount $ _msg1115_header ^. msmHeader_satelliteMask
+    _msg1115_signalData    <- arbitraryMsm5SignalData $ popCount $ _msg1115_header ^. msmHeader_cellMask
     pure Msg1115 {..}
 
 instance Arbitrary Msg1116 where
   arbitrary = do
     _msg1116_header        <- arbitrary
     _msg1116_satelliteData <- arbitraryMsm46SatelliteData $ popCount $ _msg1116_header ^. msmHeader_satelliteMask
+    _msg1116_signalData    <- arbitraryMsm6SignalData $ popCount $ _msg1116_header ^. msmHeader_cellMask
     pure Msg1116 {..}
 
 instance Arbitrary Msg1117 where
   arbitrary = do
     _msg1117_header        <- arbitrary
     _msg1117_satelliteData <- arbitraryMsm57SatelliteData $ popCount $ _msg1117_header ^. msmHeader_satelliteMask
+    _msg1117_signalData    <- arbitraryMsm7SignalData $ popCount $ _msg1117_header ^. msmHeader_cellMask
     pure Msg1117 {..}
 
 instance Arbitrary Msg1124 where
   arbitrary = do
     _msg1124_header        <- arbitrary
     _msg1124_satelliteData <- arbitraryMsm46SatelliteData $ popCount $ _msg1124_header ^. msmHeader_satelliteMask
+    _msg1124_signalData    <- arbitraryMsm4SignalData $ popCount $ _msg1124_header ^. msmHeader_cellMask
     pure Msg1124 {..}
 
 instance Arbitrary Msg1125 where
   arbitrary = do
     _msg1125_header       <- arbitrary
     _msg1125_satelliteData <- arbitraryMsm57SatelliteData $ popCount $ _msg1125_header ^. msmHeader_satelliteMask
+    _msg1125_signalData    <- arbitraryMsm5SignalData $ popCount $ _msg1125_header ^. msmHeader_cellMask
     pure Msg1125 {..}
 
 instance Arbitrary Msg1126 where
   arbitrary = do
     _msg1126_header        <- arbitrary
     _msg1126_satelliteData <- arbitraryMsm46SatelliteData $ popCount $ _msg1126_header ^. msmHeader_satelliteMask
+    _msg1126_signalData    <- arbitraryMsm6SignalData $ popCount $ _msg1126_header ^. msmHeader_cellMask
     pure Msg1126 {..}
 
 instance Arbitrary Msg1127 where
   arbitrary = do
     _msg1127_header        <- arbitrary
     _msg1127_satelliteData <- arbitraryMsm57SatelliteData $ popCount $ _msg1127_header ^. msmHeader_satelliteMask
+    _msg1127_signalData    <- arbitraryMsm7SignalData $ popCount $ _msg1127_header ^. msmHeader_cellMask
     pure Msg1127 {..}
 
 testMsg1074 :: TestTree

--- a/haskell/test/Test/Data/RTCM3/MSM.hs
+++ b/haskell/test/Test/Data/RTCM3/MSM.hs
@@ -45,13 +45,266 @@ instance Arbitrary Msg1074 where
     _msg1074_header <- arbitrary
     pure Msg1074 {..}
 
+instance Arbitrary Msg1075 where
+  arbitrary = do
+    _msg1075_header <- arbitrary
+    pure Msg1075 {..}
+
+instance Arbitrary Msg1076 where
+  arbitrary = do
+    _msg1076_header <- arbitrary
+    pure Msg1076 {..}
+
+instance Arbitrary Msg1077 where
+  arbitrary = do
+    _msg1077_header <- arbitrary
+    pure Msg1077 {..}
+
+instance Arbitrary Msg1084 where
+  arbitrary = do
+    _msg1084_header <- arbitrary
+    pure Msg1084 {..}
+
+instance Arbitrary Msg1085 where
+  arbitrary = do
+    _msg1085_header <- arbitrary
+    pure Msg1085 {..}
+
+instance Arbitrary Msg1086 where
+  arbitrary = do
+    _msg1086_header <- arbitrary
+    pure Msg1086 {..}
+
+instance Arbitrary Msg1087 where
+  arbitrary = do
+    _msg1087_header <- arbitrary
+    pure Msg1087 {..}
+
+instance Arbitrary Msg1094 where
+  arbitrary = do
+    _msg1094_header <- arbitrary
+    pure Msg1094 {..}
+
+instance Arbitrary Msg1095 where
+  arbitrary = do
+    _msg1095_header <- arbitrary
+    pure Msg1095 {..}
+
+instance Arbitrary Msg1096 where
+  arbitrary = do
+    _msg1096_header <- arbitrary
+    pure Msg1096 {..}
+
+instance Arbitrary Msg1097 where
+  arbitrary = do
+    _msg1097_header <- arbitrary
+    pure Msg1097 {..}
+
+instance Arbitrary Msg1104 where
+  arbitrary = do
+    _msg1104_header <- arbitrary
+    pure Msg1104 {..}
+
+instance Arbitrary Msg1105 where
+  arbitrary = do
+    _msg1105_header <- arbitrary
+    pure Msg1105 {..}
+
+instance Arbitrary Msg1106 where
+  arbitrary = do
+    _msg1106_header <- arbitrary
+    pure Msg1106 {..}
+
+instance Arbitrary Msg1107 where
+  arbitrary = do
+    _msg1107_header <- arbitrary
+    pure Msg1107 {..}
+
+instance Arbitrary Msg1114 where
+  arbitrary = do
+    _msg1114_header <- arbitrary
+    pure Msg1114 {..}
+
+instance Arbitrary Msg1115 where
+  arbitrary = do
+    _msg1115_header <- arbitrary
+    pure Msg1115 {..}
+
+instance Arbitrary Msg1116 where
+  arbitrary = do
+    _msg1116_header <- arbitrary
+    pure Msg1116 {..}
+
+instance Arbitrary Msg1117 where
+  arbitrary = do
+    _msg1117_header <- arbitrary
+    pure Msg1117 {..}
+
+instance Arbitrary Msg1124 where
+  arbitrary = do
+    _msg1124_header <- arbitrary
+    pure Msg1124 {..}
+
+instance Arbitrary Msg1125 where
+  arbitrary = do
+    _msg1125_header <- arbitrary
+    pure Msg1125 {..}
+
+instance Arbitrary Msg1126 where
+  arbitrary = do
+    _msg1126_header <- arbitrary
+    pure Msg1126 {..}
+
+instance Arbitrary Msg1127 where
+  arbitrary = do
+    _msg1127_header <- arbitrary
+    pure Msg1127 {..}
+
 testMsg1074 :: TestTree
 testMsg1074 =
   testProperty "Roundtrip Msg1074" $ \m ->
     decode (encode m) == (m :: Msg1074)
 
+testMsg1075 :: TestTree
+testMsg1075 =
+  testProperty "Roundtrip Msg1075" $ \m ->
+    decode (encode m) == (m :: Msg1075)
+
+testMsg1076 :: TestTree
+testMsg1076 =
+  testProperty "Roundtrip Msg1076" $ \m ->
+    decode (encode m) == (m :: Msg1076)
+
+testMsg1077 :: TestTree
+testMsg1077 =
+  testProperty "Roundtrip Msg1077" $ \m ->
+    decode (encode m) == (m :: Msg1077)
+
+testMsg1084 :: TestTree
+testMsg1084 =
+  testProperty "Roundtrip Msg1084" $ \m ->
+    decode (encode m) == (m :: Msg1084)
+
+testMsg1085 :: TestTree
+testMsg1085 =
+  testProperty "Roundtrip Msg1085" $ \m ->
+    decode (encode m) == (m :: Msg1085)
+
+testMsg1086 :: TestTree
+testMsg1086 =
+  testProperty "Roundtrip Msg1086" $ \m ->
+    decode (encode m) == (m :: Msg1086)
+
+testMsg1087 :: TestTree
+testMsg1087 =
+  testProperty "Roundtrip Msg1087" $ \m ->
+    decode (encode m) == (m :: Msg1087)
+
+testMsg1094 :: TestTree
+testMsg1094 =
+  testProperty "Roundtrip Msg1094" $ \m ->
+    decode (encode m) == (m :: Msg1094)
+
+testMsg1095 :: TestTree
+testMsg1095 =
+  testProperty "Roundtrip Msg1095" $ \m ->
+    decode (encode m) == (m :: Msg1095)
+
+testMsg1096 :: TestTree
+testMsg1096 =
+  testProperty "Roundtrip Msg1096" $ \m ->
+    decode (encode m) == (m :: Msg1096)
+
+testMsg1097 :: TestTree
+testMsg1097 =
+  testProperty "Roundtrip Msg1097" $ \m ->
+    decode (encode m) == (m :: Msg1097)
+
+testMsg1104 :: TestTree
+testMsg1104 =
+  testProperty "Roundtrip Msg1104" $ \m ->
+    decode (encode m) == (m :: Msg1104)
+
+testMsg1105 :: TestTree
+testMsg1105 =
+  testProperty "Roundtrip Msg1105" $ \m ->
+    decode (encode m) == (m :: Msg1105)
+
+testMsg1106 :: TestTree
+testMsg1106 =
+  testProperty "Roundtrip Msg1106" $ \m ->
+    decode (encode m) == (m :: Msg1106)
+
+testMsg1107 :: TestTree
+testMsg1107 =
+  testProperty "Roundtrip Msg1107" $ \m ->
+    decode (encode m) == (m :: Msg1107)
+
+testMsg1114 :: TestTree
+testMsg1114 =
+  testProperty "Roundtrip Msg1114" $ \m ->
+    decode (encode m) == (m :: Msg1114)
+
+testMsg1115 :: TestTree
+testMsg1115 =
+  testProperty "Roundtrip Msg1115" $ \m ->
+    decode (encode m) == (m :: Msg1115)
+
+testMsg1116 :: TestTree
+testMsg1116 =
+  testProperty "Roundtrip Msg1116" $ \m ->
+    decode (encode m) == (m :: Msg1116)
+
+testMsg1117 :: TestTree
+testMsg1117 =
+  testProperty "Roundtrip Msg1117" $ \m ->
+    decode (encode m) == (m :: Msg1117)
+
+testMsg1124 :: TestTree
+testMsg1124 =
+  testProperty "Roundtrip Msg1124" $ \m ->
+    decode (encode m) == (m :: Msg1124)
+
+testMsg1125 :: TestTree
+testMsg1125 =
+  testProperty "Roundtrip Msg1125" $ \m ->
+    decode (encode m) == (m :: Msg1125)
+
+testMsg1126 :: TestTree
+testMsg1126 =
+  testProperty "Roundtrip Msg1126" $ \m ->
+    decode (encode m) == (m :: Msg1126)
+
+testMsg1127 :: TestTree
+testMsg1127 =
+  testProperty "Roundtrip Msg1127" $ \m ->
+    decode (encode m) == (m :: Msg1127)
+
 tests :: TestTree
 tests =
   testGroup "MSM tests"
     [ testMsg1074
+    , testMsg1075
+    , testMsg1076
+    , testMsg1077
+    , testMsg1084
+    , testMsg1085
+    , testMsg1086
+    , testMsg1087
+    , testMsg1094
+    , testMsg1095
+    , testMsg1096
+    , testMsg1097
+    , testMsg1104
+    , testMsg1105
+    , testMsg1106
+    , testMsg1107
+    , testMsg1114
+    , testMsg1115
+    , testMsg1116
+    , testMsg1117
+    , testMsg1124
+    , testMsg1125
+    , testMsg1126
+    , testMsg1127
     ]

--- a/haskell/test/Test/Data/RTCM3/MSM.hs
+++ b/haskell/test/Test/Data/RTCM3/MSM.hs
@@ -15,6 +15,7 @@ module Test.Data.RTCM3.MSM
   ) where
 
 import BasicPrelude
+import Control.Lens
 import Data.Binary
 import Data.Bits
 import Data.RTCM3
@@ -40,9 +41,16 @@ instance Arbitrary MsmHeader where
     _msmHeader_cellMask          <- arbitraryWord x
     pure MsmHeader {..}
 
+arbitraryMsm46SatelliteData :: Int -> Gen Msm46SatelliteData
+arbitraryMsm46SatelliteData n = do
+  _msm46SatelliteData_roughRanges       <- replicateM n $ arbitraryWord 8
+  _msm46SatelliteData_roughRangesModulo <- replicateM n $ arbitraryWord 10
+  pure Msm46SatelliteData {..}
+
 instance Arbitrary Msg1074 where
   arbitrary = do
-    _msg1074_header <- arbitrary
+    _msg1074_header        <- arbitrary
+    _msg1074_satelliteData <- arbitraryMsm46SatelliteData $ popCount $ _msg1074_header ^. msmHeader_satelliteMask
     pure Msg1074 {..}
 
 instance Arbitrary Msg1075 where
@@ -52,7 +60,8 @@ instance Arbitrary Msg1075 where
 
 instance Arbitrary Msg1076 where
   arbitrary = do
-    _msg1076_header <- arbitrary
+    _msg1076_header        <- arbitrary
+    _msg1076_satelliteData <- arbitraryMsm46SatelliteData $ popCount $ _msg1076_header ^. msmHeader_satelliteMask
     pure Msg1076 {..}
 
 instance Arbitrary Msg1077 where
@@ -63,6 +72,7 @@ instance Arbitrary Msg1077 where
 instance Arbitrary Msg1084 where
   arbitrary = do
     _msg1084_header <- arbitrary
+    _msg1084_satelliteData <- arbitraryMsm46SatelliteData $ popCount $ _msg1084_header ^. msmHeader_satelliteMask
     pure Msg1084 {..}
 
 instance Arbitrary Msg1085 where
@@ -72,7 +82,8 @@ instance Arbitrary Msg1085 where
 
 instance Arbitrary Msg1086 where
   arbitrary = do
-    _msg1086_header <- arbitrary
+    _msg1086_header        <- arbitrary
+    _msg1086_satelliteData <- arbitraryMsm46SatelliteData $ popCount $ _msg1086_header ^. msmHeader_satelliteMask
     pure Msg1086 {..}
 
 instance Arbitrary Msg1087 where
@@ -82,7 +93,8 @@ instance Arbitrary Msg1087 where
 
 instance Arbitrary Msg1094 where
   arbitrary = do
-    _msg1094_header <- arbitrary
+    _msg1094_header        <- arbitrary
+    _msg1094_satelliteData <- arbitraryMsm46SatelliteData $ popCount $ _msg1094_header ^. msmHeader_satelliteMask
     pure Msg1094 {..}
 
 instance Arbitrary Msg1095 where
@@ -92,7 +104,8 @@ instance Arbitrary Msg1095 where
 
 instance Arbitrary Msg1096 where
   arbitrary = do
-    _msg1096_header <- arbitrary
+    _msg1096_header        <- arbitrary
+    _msg1096_satelliteData <- arbitraryMsm46SatelliteData $ popCount $ _msg1096_header ^. msmHeader_satelliteMask
     pure Msg1096 {..}
 
 instance Arbitrary Msg1097 where
@@ -102,7 +115,8 @@ instance Arbitrary Msg1097 where
 
 instance Arbitrary Msg1104 where
   arbitrary = do
-    _msg1104_header <- arbitrary
+    _msg1104_header        <- arbitrary
+    _msg1104_satelliteData <- arbitraryMsm46SatelliteData $ popCount $ _msg1104_header ^. msmHeader_satelliteMask
     pure Msg1104 {..}
 
 instance Arbitrary Msg1105 where
@@ -112,7 +126,8 @@ instance Arbitrary Msg1105 where
 
 instance Arbitrary Msg1106 where
   arbitrary = do
-    _msg1106_header <- arbitrary
+    _msg1106_header        <- arbitrary
+    _msg1106_satelliteData <- arbitraryMsm46SatelliteData $ popCount $ _msg1106_header ^. msmHeader_satelliteMask
     pure Msg1106 {..}
 
 instance Arbitrary Msg1107 where
@@ -122,7 +137,8 @@ instance Arbitrary Msg1107 where
 
 instance Arbitrary Msg1114 where
   arbitrary = do
-    _msg1114_header <- arbitrary
+    _msg1114_header        <- arbitrary
+    _msg1114_satelliteData <- arbitraryMsm46SatelliteData $ popCount $ _msg1114_header ^. msmHeader_satelliteMask
     pure Msg1114 {..}
 
 instance Arbitrary Msg1115 where
@@ -132,7 +148,8 @@ instance Arbitrary Msg1115 where
 
 instance Arbitrary Msg1116 where
   arbitrary = do
-    _msg1116_header <- arbitrary
+    _msg1116_header        <- arbitrary
+    _msg1116_satelliteData <- arbitraryMsm46SatelliteData $ popCount $ _msg1116_header ^. msmHeader_satelliteMask
     pure Msg1116 {..}
 
 instance Arbitrary Msg1117 where
@@ -142,7 +159,8 @@ instance Arbitrary Msg1117 where
 
 instance Arbitrary Msg1124 where
   arbitrary = do
-    _msg1124_header <- arbitrary
+    _msg1124_header        <- arbitrary
+    _msg1124_satelliteData <- arbitraryMsm46SatelliteData $ popCount $ _msg1124_header ^. msmHeader_satelliteMask
     pure Msg1124 {..}
 
 instance Arbitrary Msg1125 where
@@ -152,7 +170,8 @@ instance Arbitrary Msg1125 where
 
 instance Arbitrary Msg1126 where
   arbitrary = do
-    _msg1126_header <- arbitrary
+    _msg1126_header        <- arbitrary
+    _msg1126_satelliteData <- arbitraryMsm46SatelliteData $ popCount $ _msg1126_header ^. msmHeader_satelliteMask
     pure Msg1126 {..}
 
 instance Arbitrary Msg1127 where

--- a/haskell/test/Test/Data/RTCM3/MSM.hs
+++ b/haskell/test/Test/Data/RTCM3/MSM.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE RecordWildCards   #-}
+{-# OPTIONS -fno-warn-orphans  #-}
+
+-- |
+-- Module:      Test.Data.RTCM3.MSM
+-- Copyright:   (c) 2015 Swift Navigation
+-- License:     BSD3
+-- Maintainer:  Swift Navigation <dev@swiftnav.com>
+--
+-- Test MSM module for RTCM3.
+
+module Test.Data.RTCM3.MSM
+  ( tests
+  ) where
+
+import BasicPrelude
+import Data.Binary
+import Data.Bits
+import Data.RTCM3
+import Test.Data.RTCM3.Test
+import Test.Tasty
+import Test.Tasty.QuickCheck
+
+instance Arbitrary MsmHeader where
+  arbitrary = do
+    _msmHeader_num               <- arbitraryWord 12
+    _msmHeader_station           <- arbitraryWord 12
+    _msmHeader_epoch             <- arbitraryWord 30
+    _msmHeader_multiple          <- arbitrary
+    _msmHeader_iods              <- arbitraryWord 3
+    _msmHeader_reserved          <- arbitraryWord 7
+    _msmHeader_clockSteering     <- arbitraryWord 2
+    _msmHeader_externalClock     <- arbitraryWord 2
+    _msmHeader_smoothing         <- arbitrary
+    _msmHeader_smoothingInterval <- arbitraryWord 3
+    _msmHeader_satelliteMask     <- arbitraryWord 64
+    _msmHeader_signalMask        <- arbitraryWord 32
+    let x = min 64 $ popCount _msmHeader_satelliteMask * popCount _msmHeader_signalMask
+    _msmHeader_cellMask          <- arbitraryWord x
+    pure MsmHeader {..}
+
+instance Arbitrary Msg1074 where
+  arbitrary = do
+    _msg1074_header <- arbitrary
+    pure Msg1074 {..}
+
+testMsg1074 :: TestTree
+testMsg1074 =
+  testProperty "Roundtrip Msg1074" $ \m ->
+    decode (encode m) == (m :: Msg1074)
+
+tests :: TestTree
+tests =
+  testGroup "MSM tests"
+    [ testMsg1074
+    ]

--- a/haskell/test/Test/Data/RTCM3/MSM.hs
+++ b/haskell/test/Test/Data/RTCM3/MSM.hs
@@ -43,16 +43,16 @@ instance Arbitrary MsmHeader where
 
 arbitraryMsm46SatelliteData :: Int -> Gen Msm46SatelliteData
 arbitraryMsm46SatelliteData n = do
-  _msm46SatelliteData_roughRanges       <- replicateM n $ arbitraryWord 8
-  _msm46SatelliteData_roughRangesModulo <- replicateM n $ arbitraryWord 10
+  _msm46SatelliteData_ranges       <- replicateM n $ arbitraryWord 8
+  _msm46SatelliteData_rangesModulo <- replicateM n $ arbitraryWord 10
   pure Msm46SatelliteData {..}
 
 arbitraryMsm57SatelliteData :: Int -> Gen Msm57SatelliteData
 arbitraryMsm57SatelliteData n = do
-  _msm57SatelliteData_roughRanges          <- replicateM n $ arbitraryWord 8
-  _msm57SatelliteData_extendeds            <- replicateM n $ arbitraryWord 4
-  _msm57SatelliteData_roughRangesModulo    <- replicateM n $ arbitraryWord 10
-  _msm57SatelliteData_roughPhaseRangeRates <- replicateM n $ arbitraryWord 14
+  _msm57SatelliteData_ranges          <- replicateM n $ arbitraryWord 8
+  _msm57SatelliteData_extendeds       <- replicateM n $ arbitraryWord 4
+  _msm57SatelliteData_rangesModulo    <- replicateM n $ arbitraryWord 10
+  _msm57SatelliteData_phaseRangeRates <- replicateM n $ arbitraryWord 14
   pure Msm57SatelliteData {..}
 
 arbitraryMsm4SignalData :: Int -> Gen Msm4SignalData

--- a/haskell/test/Test/Data/RTCM3/MSM.hs
+++ b/haskell/test/Test/Data/RTCM3/MSM.hs
@@ -47,6 +47,14 @@ arbitraryMsm46SatelliteData n = do
   _msm46SatelliteData_roughRangesModulo <- replicateM n $ arbitraryWord 10
   pure Msm46SatelliteData {..}
 
+arbitraryMsm57SatelliteData :: Int -> Gen Msm57SatelliteData
+arbitraryMsm57SatelliteData n = do
+  _msm57SatelliteData_roughRanges          <- replicateM n $ arbitraryWord 8
+  _msm57SatelliteData_extendeds            <- replicateM n $ arbitraryWord 4
+  _msm57SatelliteData_roughRangesModulo    <- replicateM n $ arbitraryWord 10
+  _msm57SatelliteData_roughPhaseRangeRates <- replicateM n $ arbitraryWord 14
+  pure Msm57SatelliteData {..}
+
 instance Arbitrary Msg1074 where
   arbitrary = do
     _msg1074_header        <- arbitrary
@@ -55,7 +63,8 @@ instance Arbitrary Msg1074 where
 
 instance Arbitrary Msg1075 where
   arbitrary = do
-    _msg1075_header <- arbitrary
+    _msg1075_header        <- arbitrary
+    _msg1075_satelliteData <- arbitraryMsm57SatelliteData $ popCount $ _msg1075_header ^. msmHeader_satelliteMask
     pure Msg1075 {..}
 
 instance Arbitrary Msg1076 where
@@ -66,7 +75,8 @@ instance Arbitrary Msg1076 where
 
 instance Arbitrary Msg1077 where
   arbitrary = do
-    _msg1077_header <- arbitrary
+    _msg1077_header        <- arbitrary
+    _msg1077_satelliteData <- arbitraryMsm57SatelliteData $ popCount $ _msg1077_header ^. msmHeader_satelliteMask
     pure Msg1077 {..}
 
 instance Arbitrary Msg1084 where
@@ -77,7 +87,8 @@ instance Arbitrary Msg1084 where
 
 instance Arbitrary Msg1085 where
   arbitrary = do
-    _msg1085_header <- arbitrary
+    _msg1085_header        <- arbitrary
+    _msg1085_satelliteData <- arbitraryMsm57SatelliteData $ popCount $ _msg1085_header ^. msmHeader_satelliteMask
     pure Msg1085 {..}
 
 instance Arbitrary Msg1086 where
@@ -88,7 +99,8 @@ instance Arbitrary Msg1086 where
 
 instance Arbitrary Msg1087 where
   arbitrary = do
-    _msg1087_header <- arbitrary
+    _msg1087_header        <- arbitrary
+    _msg1087_satelliteData <- arbitraryMsm57SatelliteData $ popCount $ _msg1087_header ^. msmHeader_satelliteMask
     pure Msg1087 {..}
 
 instance Arbitrary Msg1094 where
@@ -99,7 +111,8 @@ instance Arbitrary Msg1094 where
 
 instance Arbitrary Msg1095 where
   arbitrary = do
-    _msg1095_header <- arbitrary
+    _msg1095_header        <- arbitrary
+    _msg1095_satelliteData <- arbitraryMsm57SatelliteData $ popCount $ _msg1095_header ^. msmHeader_satelliteMask
     pure Msg1095 {..}
 
 instance Arbitrary Msg1096 where
@@ -110,7 +123,8 @@ instance Arbitrary Msg1096 where
 
 instance Arbitrary Msg1097 where
   arbitrary = do
-    _msg1097_header <- arbitrary
+    _msg1097_header        <- arbitrary
+    _msg1097_satelliteData <- arbitraryMsm57SatelliteData $ popCount $ _msg1097_header ^. msmHeader_satelliteMask
     pure Msg1097 {..}
 
 instance Arbitrary Msg1104 where
@@ -121,7 +135,8 @@ instance Arbitrary Msg1104 where
 
 instance Arbitrary Msg1105 where
   arbitrary = do
-    _msg1105_header <- arbitrary
+    _msg1105_header        <- arbitrary
+    _msg1105_satelliteData <- arbitraryMsm57SatelliteData $ popCount $ _msg1105_header ^. msmHeader_satelliteMask
     pure Msg1105 {..}
 
 instance Arbitrary Msg1106 where
@@ -132,7 +147,8 @@ instance Arbitrary Msg1106 where
 
 instance Arbitrary Msg1107 where
   arbitrary = do
-    _msg1107_header <- arbitrary
+    _msg1107_header        <- arbitrary
+    _msg1107_satelliteData <- arbitraryMsm57SatelliteData $ popCount $ _msg1107_header ^. msmHeader_satelliteMask
     pure Msg1107 {..}
 
 instance Arbitrary Msg1114 where
@@ -143,7 +159,8 @@ instance Arbitrary Msg1114 where
 
 instance Arbitrary Msg1115 where
   arbitrary = do
-    _msg1115_header <- arbitrary
+    _msg1115_header        <- arbitrary
+    _msg1115_satelliteData <- arbitraryMsm57SatelliteData $ popCount $ _msg1115_header ^. msmHeader_satelliteMask
     pure Msg1115 {..}
 
 instance Arbitrary Msg1116 where
@@ -154,7 +171,8 @@ instance Arbitrary Msg1116 where
 
 instance Arbitrary Msg1117 where
   arbitrary = do
-    _msg1117_header <- arbitrary
+    _msg1117_header        <- arbitrary
+    _msg1117_satelliteData <- arbitraryMsm57SatelliteData $ popCount $ _msg1117_header ^. msmHeader_satelliteMask
     pure Msg1117 {..}
 
 instance Arbitrary Msg1124 where
@@ -165,7 +183,8 @@ instance Arbitrary Msg1124 where
 
 instance Arbitrary Msg1125 where
   arbitrary = do
-    _msg1125_header <- arbitrary
+    _msg1125_header       <- arbitrary
+    _msg1125_satelliteData <- arbitraryMsm57SatelliteData $ popCount $ _msg1125_header ^. msmHeader_satelliteMask
     pure Msg1125 {..}
 
 instance Arbitrary Msg1126 where
@@ -176,7 +195,8 @@ instance Arbitrary Msg1126 where
 
 instance Arbitrary Msg1127 where
   arbitrary = do
-    _msg1127_header <- arbitrary
+    _msg1127_header        <- arbitrary
+    _msg1127_satelliteData <- arbitraryMsm57SatelliteData $ popCount $ _msg1127_header ^. msmHeader_satelliteMask
     pure Msg1127 {..}
 
 testMsg1074 :: TestTree


### PR DESCRIPTION
Provides MSM support for Haskell RTCM. MSM4, MSM5, MSM6, and MSM7 are supported for 107x, 108x, 109x, 110x, 111x, and 112x.

/cc @ljbade @anth-cole @scarcanague @nsirola 