### PR TITLE
Assign L1P/L2P SBP code_t from msm to match 1012 behavior

### DIFF
--- a/c/include/rtcm_logging.h
+++ b/c/include/rtcm_logging.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef LIBRTCM_LOGGING_H
+#define LIBRTCM_LOGGING_H
+
+#include <stdint.h>
+
+/*
+ * from syslog.h
+ */
+#define LOG_EMERG   0 /* system is unusable */
+#define LOG_ALERT   1 /* action must be taken immediately */
+#define LOG_CRIT    2 /* critical conditions */
+#define LOG_ERR     3 /* error conditions */
+#define LOG_WARNING 4 /* warning conditions */
+#define LOG_NOTICE  5 /* normal but significant condition */
+#define LOG_INFO    6 /* informational */
+#define LOG_DEBUG   7 /* debug-level messages */
+
+typedef void (*rtcm_log_callback)(uint8_t level, uint8_t *msg, uint16_t len);
+
+void rtcm_init_logging(rtcm_log_callback callback);
+void rtcm_log(uint8_t level, uint8_t *msg, uint16_t len);
+
+#endif /* LIBRTCM_LOGGING_H */

--- a/c/src/CMakeLists.txt
+++ b/c/src/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.7)
 
 file(GLOB librtcm_HEADERS "${PROJECT_SOURCE_DIR}/include/*.h")
 
-add_library (rtcm rtcm3_decode.c rtcm3_msm_utils.c bits.c)
+add_library (rtcm rtcm3_decode.c rtcm3_msm_utils.c bits.c rtcm_logging.c)
 target_link_libraries(rtcm m)
 target_include_directories (rtcm PUBLIC ../include)
 

--- a/c/src/rtcm3_msm_utils.c
+++ b/c/src/rtcm3_msm_utils.c
@@ -221,11 +221,11 @@ static code_t get_msm_glo_code(uint8_t signal_id) {
   /* RTCM 10403.3 Table 3.5-96 */
   switch (signal_id) {
     case 2: /* 1C */
+    case 3: /* 1P */
       return CODE_GLO_L1OF;
-    /* case 3: 1P */
     case 8: /* 2C */
+    case 9: /* 2P */
       return CODE_GLO_L2OF;
-    /* case 9: 2P */
     default:
       return CODE_INVALID;
   }

--- a/c/src/rtcm3_msm_utils.c
+++ b/c/src/rtcm3_msm_utils.c
@@ -13,6 +13,7 @@
 #include "rtcm3_msm_utils.h"
 #include <assert.h>
 #include <stdio.h>
+#include "rtcm_logging.h"
 
 /** Find the frequency of an MSM signal
  *
@@ -217,14 +218,19 @@ static uint8_t get_msm_glo_prn(uint8_t sat_id) {
   return (prn <= GLO_LAST_PRN) ? prn : PRN_INVALID;
 }
 
+#define MSM_L1P_WARN_MSG "Received GLO L1P MSM Message from base station"
+#define MSM_L2P_WARN_MSG "Received GLO L2P MSM Message from base station"
+
 static code_t get_msm_glo_code(uint8_t signal_id) {
   /* RTCM 10403.3 Table 3.5-96 */
   switch (signal_id) {
-    case 2: /* 1C */
     case 3: /* 1P */
+      rtcm_log(LOG_WARNING, (uint8_t *)MSM_L1P_WARN_MSG, sizeof(MSM_L1P_WARN_MSG));
+    case 2: /* 1C */
       return CODE_GLO_L1OF;
-    case 8: /* 2C */
     case 9: /* 2P */
+      rtcm_log(LOG_WARNING, (uint8_t *)MSM_L2P_WARN_MSG, sizeof(MSM_L2P_WARN_MSG));
+    case 8: /* 2C */
       return CODE_GLO_L2OF;
     default:
       return CODE_INVALID;

--- a/c/src/rtcm_logging.c
+++ b/c/src/rtcm_logging.c
@@ -1,0 +1,30 @@
+/*
+* Copyright (C) 2018 Swift Navigation Inc.
+* Contact: Swift Navigation <dev@swiftnav.com>
+*
+* This source is subject to the license found in the file 'LICENSE' which must
+* be distributed together with this source. All other rights reserved.
+*
+* THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+* EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+*/
+
+#include <stdlib.h>
+
+#include "rtcm_logging.h"
+
+static rtcm_log_callback log_callback_ = NULL;
+
+void rtcm_init_logging(rtcm_log_callback callback)
+{
+  log_callback_ = callback;
+}
+
+void rtcm_log(uint8_t level, uint8_t *msg, uint16_t len)
+{
+  if (log_callback_ != NULL) {
+    log_callback_(level, msg, len);
+  }
+}
+

--- a/c/test/rtcm_decoder_tests.h
+++ b/c/test/rtcm_decoder_tests.h
@@ -35,6 +35,7 @@ static void test_rtcm_random_bits(void);
 static void test_msm_bit_utils(void);
 static void test_msm_sid_conversion(void);
 static void test_msm_glo_fcn(void);
+static void test_logging(void);
 
 bool msgobs_equals(const rtcm_obs_message *msg_in,
                    const rtcm_obs_message *msg_out);


### PR DESCRIPTION
From discussion around swift-nav/gnss-converters#87

Conversion in that codebase assigns the currently supported SBP codes for GLO L1/L2 signals to both variants. This change bring the MSM decoding in line with that behavior.