### PR TITLE
Add context to logging to pass sbp state from gnss converters

### DIFF
--- a/c/include/rtcm_logging.h
+++ b/c/include/rtcm_logging.h
@@ -15,6 +15,7 @@
 
 #include <stdint.h>
 
+#ifdef LIBRTCM_LOG_INTERNAL
 /*
  * from syslog.h
  */
@@ -26,6 +27,8 @@
 #define LOG_NOTICE  5 /* normal but significant condition */
 #define LOG_INFO    6 /* informational */
 #define LOG_DEBUG   7 /* debug-level messages */
+
+#endif /* RCTM_LOG_INTERNAL */
 
 typedef void (*rtcm_log_callback)(uint8_t level, uint8_t *msg, uint16_t len, void *context);
 

--- a/c/include/rtcm_logging.h
+++ b/c/include/rtcm_logging.h
@@ -27,9 +27,9 @@
 #define LOG_INFO    6 /* informational */
 #define LOG_DEBUG   7 /* debug-level messages */
 
-typedef void (*rtcm_log_callback)(uint8_t level, uint8_t *msg, uint16_t len);
+typedef void (*rtcm_log_callback)(uint8_t level, uint8_t *msg, uint16_t len, void *context);
 
-void rtcm_init_logging(rtcm_log_callback callback);
+void rtcm_init_logging(rtcm_log_callback callback, void *context);
 void rtcm_log(uint8_t level, uint8_t *msg, uint16_t len);
 
 #endif /* LIBRTCM_LOGGING_H */

--- a/c/src/rtcm3_msm_utils.c
+++ b/c/src/rtcm3_msm_utils.c
@@ -13,6 +13,8 @@
 #include "rtcm3_msm_utils.h"
 #include <assert.h>
 #include <stdio.h>
+
+#define LIBRTCM_LOG_INTERNAL
 #include "rtcm_logging.h"
 
 /** Find the frequency of an MSM signal

--- a/c/src/rtcm_logging.c
+++ b/c/src/rtcm_logging.c
@@ -15,16 +15,18 @@
 #include "rtcm_logging.h"
 
 static rtcm_log_callback log_callback_ = NULL;
+static void *log_context_ = NULL;
 
-void rtcm_init_logging(rtcm_log_callback callback)
+void rtcm_init_logging(rtcm_log_callback callback, void *context)
 {
   log_callback_ = callback;
+  log_context_ = context;
 }
 
 void rtcm_log(uint8_t level, uint8_t *msg, uint16_t len)
 {
   if (log_callback_ != NULL) {
-    log_callback_(level, msg, len);
+    log_callback_(level, msg, len, log_context_);
   }
 }
 

--- a/c/test/rtcm_decoder_tests.c
+++ b/c/test/rtcm_decoder_tests.c
@@ -1784,22 +1784,23 @@ void test_msm_glo_fcn(void) {
 #define TEST_LOG_MSG "A message of length 22"
 #define TEST_LOG_LEN sizeof(TEST_LOG_MSG)
 
-static int callback_count = 0;
 
-static void test_rtcm_log_callback(uint8_t level, uint8_t *msg, uint16_t length)
+static void test_rtcm_log_callback(uint8_t level, uint8_t *msg, uint16_t length, void *context)
 {
+  int *callback_count = (int *)context;
   assert(level == TEST_LOG_LEVEL);
   assert(length == TEST_LOG_LEN);
   assert(strcmp((char *)msg, TEST_LOG_MSG) == 0);
-  callback_count++;
+  (*callback_count)++;
 }
 
 void test_logging(void)
 {
-  rtcm_init_logging(NULL);
+  int callback_count = 0;
+  rtcm_init_logging(NULL, NULL);
   rtcm_log(0, NULL, 0);
   assert(callback_count == 0);
-  rtcm_init_logging(test_rtcm_log_callback);
+  rtcm_init_logging(test_rtcm_log_callback, &callback_count);
   rtcm_log(TEST_LOG_LEVEL, (uint8_t *)TEST_LOG_MSG, TEST_LOG_LEN);
   assert(callback_count == 1);
 }

--- a/c/test/rtcm_decoder_tests.c
+++ b/c/test/rtcm_decoder_tests.c
@@ -16,12 +16,13 @@
 #include <string.h>
 #include <rtcm3_decode.h>
 #include <rtcm3_messages.h>
-#include <rtcm_logging.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include "bits.h"
 #include "rtcm_encoder.h"
+#define LIBRTCM_LOG_INTERNAL
+#include <rtcm_logging.h>
 
 int main(void) {
   test_msm_bit_utils();


### PR DESCRIPTION
Logging callback added in #45 needs context pointer in order to function with `gnss-converters` log to sbp functionality