### PR TITLE
EX-472: limit maximum antenna height in RTCM 1006

### DIFF
--- a/c/include/rtcm3/constants.h
+++ b/c/include/rtcm3/constants.h
@@ -44,6 +44,9 @@
 /* maximum value for time-of-day in integer milliseconds */
 #define RTCM_GLO_MAX_TOW_MS (24 * 3600 * 1000 - 1)
 
+/* maximum value for antenna height DF028 */
+#define RTCM_1006_MAX_ANTENNA_HEIGHT_M 6.5535
+
 /** 2^-4 */
 #define C_1_2P4 0.0625
 /** 2^-8 */

--- a/c/src/encode.c
+++ b/c/src/encode.c
@@ -574,7 +574,13 @@ uint16_t rtcm3_encode_1006(const rtcm_msg_1006 *msg_1006, uint8_t buff[]) {
   rtcm_setbitu(buff, bit, 12, 1006);
   bit += 12;
   rtcm3_encode_1005_base(&msg_1006->msg_1005, buff, &bit);
-  rtcm_setbitu(buff, bit, 16, (uint16_t)round(msg_1006->ant_height * 10000.0));
+  double ant_height = msg_1006->ant_height;
+  if (ant_height < 0.0) {
+    ant_height = 0.0;
+  } else if (ant_height > RTCM_1006_MAX_ANTENNA_HEIGHT_M) {
+    ant_height = RTCM_1006_MAX_ANTENNA_HEIGHT_M;
+  }
+  rtcm_setbitu(buff, bit, 16, (uint16_t)round(ant_height * 10000.0));
   bit += 16;
 
   /* Round number of bits up to nearest whole byte. */


### PR DESCRIPTION
Add constant for maximum antenna height (to be ultimately used to check the input from console), and saturate the antenna height to max value when encoding