### PR TITLE
Rename RTCM ephemerides structure name

### DIFF
--- a/c/include/rtcm3/messages.h
+++ b/c/include/rtcm3/messages.h
@@ -207,10 +207,10 @@ typedef struct {
  */
 typedef struct {
   union {
-    int8_t tgd_gps_s;
-    int8_t tgd_qzss_s;
-    int16_t tgd_bds_s[2];
-    int16_t tgd_gal_s[2];
+	int32_t tgd_gps_s;
+    int32_t tgd_qzss_s;
+    int32_t tgd_bds_s[2];
+    int32_t tgd_gal_s[2];
   };
   int32_t crc;
   int32_t crs;

--- a/c/include/rtcm3/messages.h
+++ b/c/include/rtcm3/messages.h
@@ -208,9 +208,9 @@ typedef struct {
 typedef struct {
   union {
     int8_t tgd_gps_s;
-    double tgd_qzss_s;
-    double tgd_bds_s[2];
-    double tgd_gal_s[2];
+    int8_t tgd_qzss_s;
+    int16_t tgd_bds_s[2];
+    int16_t tgd_gal_s[2];
   };
   int32_t crc;
   int32_t crs;
@@ -233,7 +233,7 @@ typedef struct {
   uint32_t toc;
   uint16_t iodc;
   uint16_t iode;
-} ephemeris_kepler_t;
+} ephemeris_kepler_raw_rtcm_t;
 
 /** Structure containing the SBAS ephemeris for one satellite. */
 typedef struct {
@@ -242,7 +242,7 @@ typedef struct {
   double acc[3];
   double a_gf0;
   double a_gf1;
-} ephemeris_xyz_t;
+} ephemeris_xyz_rtcm_t;
 
 /** Structure containing the GLONASS ephemeris for one satellite. */
 typedef struct {
@@ -256,7 +256,7 @@ typedef struct {
 
   uint8_t fcn;
   uint8_t iod;
-} ephemeris_glo_t;
+} ephemeris_glo_raw_rtcm_t;
 
 /** Structure containing the ephemeris for one satellite. */
 typedef struct {
@@ -269,9 +269,9 @@ typedef struct {
   uint8_t valid;
   uint8_t health_bits;
   union {
-    ephemeris_kepler_t kepler;
-    ephemeris_xyz_t xyz;
-    ephemeris_glo_t glo;
+	  ephemeris_kepler_raw_rtcm_t kepler;
+	  ephemeris_xyz_rtcm_t xyz;
+	  ephemeris_glo_raw_rtcm_t glo;
   };
 } rtcm_msg_eph;
 

--- a/c/src/eph_decode.c
+++ b/c/src/eph_decode.c
@@ -373,6 +373,7 @@ rtcm3_rc rtcm3_decode_gal_eph_fnav(const uint8_t buff[],
 
   msg_eph->kepler.tgd_gal_s[0] = rtcm_getbits(buff, bit, 10);
   bit += 10;
+  msg_eph->kepler.tgd_gal_s[1] = 0;
   msg_eph->health_bits = rtcm_getbits(buff, bit, 3);
   bit += 3;
   /* reserved */ rtcm_getbits(buff, bit, 7);

--- a/c/src/eph_decode.c
+++ b/c/src/eph_decode.c
@@ -257,6 +257,7 @@ rtcm3_rc rtcm3_decode_bds_eph(const uint8_t buff[], rtcm_msg_eph *msg_eph) {
   msg_eph->kepler.tgd_bds_s[1] = rtcm_getbits(buff, bit, 10);
   bit += 10;
   msg_eph->valid = rtcm_getbitu(buff, bit, 1);
+  msg_eph->health_bits = msg_eph->valid;
   bit += 1;
   return RC_OK;
 }


### PR DESCRIPTION
- librtcm defines kepler model ehpemeris structure as ephemeris_kepler_t which conflicts to libswiftnav
- The structure in librtcm is the raw un-decoded parameters retrieved from RTCM message
- Rename these structure to xxx_raw_rtcm_t indicates it is for rtcm and contains raw message
- For tgd_gal_s, tgd_bds_s and tgd_qzss_s, updated data type to int, because it is the raw data(without scale factor applied)
- Decode the BDS ephemerides health bit, as it is not set but tested by gnss-converters check_rtcm3.c line 395
- Set Gal tgd[1] to zero when decoding Gal fnav message, as it is not set but tested by gnss-converters check_rtcm3.c line 335
- Created gnss-converters PR https://github.com/swift-nav/gnss-converters/pull/162 to prove all tests pass for this updates. 