### PR TITLE
Use system defined install paths

### DIFF
--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 2.8.7)
 project(librtcm)
+include(GNUInstallDirs)
 add_subdirectory (src)
 add_subdirectory (test)

--- a/c/src/CMakeLists.txt
+++ b/c/src/CMakeLists.txt
@@ -50,5 +50,5 @@ if (CMAKE_C_COMPILER_VERSION VERSION_GREATER 5.0)
    target_compile_options(rtcm PRIVATE "-Wfloat-conversion")
 endif()
 
-install(TARGETS rtcm DESTINATION lib${LIB_SUFFIX})
-install(FILES ${librtcm_HEADERS} DESTINATION include/rtcm3)
+install(TARGETS rtcm DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR})
+install(FILES ${librtcm_HEADERS} DESTINATION ${CMAKE_INSTALL_FULL_INCLUDEDIR}/rtcm3)


### PR DESCRIPTION
Use the cmake module GNUInstallDirs to define standard system install paths. This module works well when providing an installation prefix or destdir to cmake/make. This will replace all hard coded installation paths