### PR TITLE
Import standard cmake modules, standardise dependency resolution [ESD-1246] [ESD-1247]

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "c/cmake/common"]
+	path = c/cmake/common
+	url = https://github.com/swift-nav/cmake.git

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -12,6 +12,5 @@ swift_create_project_options(
 add_subdirectory (src)
 
 if(librtcm_BUILD_TESTS)
-  enable_testing()
   add_subdirectory (test)
 endif()

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -4,6 +4,7 @@ project(librtcm)
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake" "${CMAKE_CURRENT_LIST_DIR}/cmake/common")
 
 include(GNUInstallDirs)
+include(CCache)
 include(SwiftCmakeOptions)
 swift_create_project_options(
     HAS_TESTS

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -5,7 +5,9 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake" "${CMAKE_CURRENT_LIST_DI
 
 include(GNUInstallDirs)
 include(SwiftCmakeOptions)
-swift_create_project_options()
+swift_create_project_options(
+    HAS_TESTS
+    )
 
 add_subdirectory (src)
 

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -12,8 +12,12 @@ swift_create_project_options(
 include(ClangFormat)
 swift_setup_clang_format()
 
+include(ClangTidy)
+
 add_subdirectory (src)
 
 if(librtcm_BUILD_TESTS)
   add_subdirectory (test)
 endif()
+
+swift_setup_clang_tidy()

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -13,6 +13,7 @@ include(ClangFormat)
 swift_setup_clang_format()
 
 include(ClangTidy)
+swift_setup_clang_tidy(FILES "src/*.c")
 
 add_subdirectory (src)
 
@@ -20,4 +21,3 @@ if(librtcm_BUILD_TESTS)
   add_subdirectory (test)
 endif()
 
-swift_setup_clang_tidy()

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -14,7 +14,7 @@ include(ClangFormat)
 swift_setup_clang_format()
 
 include(ClangTidy)
-swift_setup_clang_tidy(FILES "src/*.c")
+swift_setup_clang_tidy(PATTERNS "src/*.c")
 
 add_subdirectory (src)
 

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -9,6 +9,9 @@ swift_create_project_options(
     HAS_TESTS
     )
 
+include(ClangFormat)
+swift_setup_clang_format()
+
 add_subdirectory (src)
 
 if(librtcm_BUILD_TESTS)

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -5,9 +5,11 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake" "${CMAKE_CURRENT_LIST_DI
 
 include(GNUInstallDirs)
 include(SwiftCmakeOptions)
+swift_create_project_options()
 
 add_subdirectory (src)
 
 if(librtcm_BUILD_TESTS)
+  enable_testing()
   add_subdirectory (test)
 endif()

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -1,5 +1,13 @@
 cmake_minimum_required(VERSION 2.8.7)
 project(librtcm)
+
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake" "${CMAKE_CURRENT_LIST_DIR}/cmake/common")
+
 include(GNUInstallDirs)
+include(SwiftCmakeOptions)
+
 add_subdirectory (src)
-add_subdirectory (test)
+
+if(librtcm_BUILD_TESTS)
+  add_subdirectory (test)
+endif()

--- a/c/src/CMakeLists.txt
+++ b/c/src/CMakeLists.txt
@@ -25,7 +25,6 @@ add_library(rtcm
 
 target_link_libraries(rtcm m)
 target_include_directories(rtcm PUBLIC ${PROJECT_SOURCE_DIR}/include)
-swift_target_enable_clang_tidy(rtcm)
 
 target_compile_options(rtcm PRIVATE "-Wall")
 target_compile_options(rtcm PRIVATE "-Wextra")

--- a/c/src/CMakeLists.txt
+++ b/c/src/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(rtcm
 
 target_link_libraries(rtcm m)
 target_include_directories(rtcm PUBLIC ${PROJECT_SOURCE_DIR}/include)
+swift_target_enable_clang_tidy(rtcm)
 
 target_compile_options(rtcm PRIVATE "-Wall")
 target_compile_options(rtcm PRIVATE "-Wextra")

--- a/c/test/CMakeLists.txt
+++ b/c/test/CMakeLists.txt
@@ -2,4 +2,10 @@ add_executable (rtcm_test rtcm_decoder_tests.c)
 
 target_link_libraries(rtcm_test LINK_PUBLIC rtcm)
 
-add_test(NAME rtcm_test COMMAND rtcm_test)
+add_custom_command(
+    TARGET rtcm_test POST_BUILD
+    COMMENT "Running unit tests"
+    COMMAND rtcm_test
+)
+target_compile_options(rtcm_test PRIVATE "-std=gnu99")
+

--- a/c/test/CMakeLists.txt
+++ b/c/test/CMakeLists.txt
@@ -1,19 +1,5 @@
-cmake_minimum_required(VERSION 2.8.7)
+add_executable (rtcm_test rtcm_decoder_tests.c)
 
-if (CMAKE_CROSSCOMPILING)
-    message(STATUS "Skipping unit tests, cross compiling")
+target_link_libraries(rtcm_test LINK_PUBLIC rtcm)
 
-else (CMAKE_CROSSCOMPILING)
-    add_executable (rtcm_test rtcm_decoder_tests.c)
-
-    target_link_libraries(rtcm_test LINK_PUBLIC rtcm)
-
-    add_custom_command(
-        TARGET rtcm_test POST_BUILD
-        COMMENT "Running unit tests"
-        COMMAND rtcm_test
-    )
-    target_compile_options(rtcm_test PRIVATE "-std=gnu99")
-
-endif(CMAKE_CROSSCOMPILING)
-
+add_test(NAME rtcm_test COMMAND rtcm_test)

--- a/c/test/CMakeLists.txt
+++ b/c/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_executable (rtcm_test rtcm_decoder_tests.c)
 
-target_link_libraries(rtcm_test LINK_PUBLIC rtcm)
+target_link_libraries(rtcm_test rtcm)
 
 add_custom_command(
     TARGET rtcm_test POST_BUILD

--- a/c/test/CMakeLists.txt
+++ b/c/test/CMakeLists.txt
@@ -7,5 +7,5 @@ add_custom_command(
     COMMENT "Running unit tests"
     COMMAND rtcm_test
 )
-target_compile_options(rtcm_test PRIVATE "-std=gnu99")
+set_target_properties(rtcm_test PROPERTIES C_STANDARD 99)
 


### PR DESCRIPTION
Integrates with swift-nav/cmake#2

Import common cmake repository. Set up package cmake options to enable/disable unit tests. This repository does not have any dependencies.