### PR TITLE
Fix 1029 encoding

### DIFF
--- a/c/src/encode.c
+++ b/c/src/encode.c
@@ -16,7 +16,6 @@
 #include <math.h>
 #include <stdbool.h>
 #include <stdint.h>
-#include <stdio.h>
 #include <string.h>
 
 #include "rtcm3/bits.h"

--- a/c/src/encode.c
+++ b/c/src/encode.c
@@ -16,6 +16,7 @@
 #include <math.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <string.h>
 
 #include "rtcm3/bits.h"
@@ -731,7 +732,6 @@ uint16_t rtcm3_encode_1012(const rtcm_obs_message *msg_1012, uint8_t buff[]) {
 uint16_t rtcm3_encode_1029(const rtcm_msg_1029 *msg_1029, uint8_t buff[]) {
   assert(msg_1029);
   uint16_t bit = 0;
-  uint16_t byte = 0;
 
   rtcm_setbitu(buff, bit, 12, 1029);
   bit += 12;
@@ -748,11 +748,11 @@ uint16_t rtcm3_encode_1029(const rtcm_msg_1029 *msg_1029, uint8_t buff[]) {
   rtcm_setbitu(buff, bit, 7, msg_1029->unicode_chars);
   bit += 7;
 
-  byte = bit / 8;
-
-  buff[byte++] = msg_1029->utf8_code_units_n;
+  rtcm_setbitu(buff, bit, 8, msg_1029->utf8_code_units_n);
+  bit += 8;
   for (uint8_t i = 0; i < msg_1029->utf8_code_units_n; i++) {
-    buff[byte++] = msg_1029->utf8_code_units[i];
+    rtcm_setbitu(buff, bit, 8, msg_1029->utf8_code_units[i]);
+    bit += 8;
   }
 
   /* Round number of bits up to nearest whole byte. */


### PR DESCRIPTION
Encode 1029 message in the same way we decode it. See [rtcm3_decode_1029](https://github.com/swift-nav/librtcm/blob/master/c/src/decode.c#L836-L866)

Bug found while trying to encode a SBP_LOG_MESSAGE into rtcm and back to sbp: I didn't get the same initial string.