### PR TITLE
fix unused variable

### DIFF
--- a/c/src/sta_decode.c
+++ b/c/src/sta_decode.c
@@ -29,6 +29,8 @@ rtcm3_rc sta_decode_fwver(const uint8_t buff[], char *fw_ver, uint8_t len) {
   uint16_t subtype_id = rtcm_getbitu(buff, bit, 8);
   bit += 8;
   /* this should never be called on anything other than msg 999:25 */
+  (void) msg_num;
+  (void) subtype_id;
   assert(msg_num == 999 && subtype_id == 25);
   GET_STR_LEN(buff, bit, fw_ver_strlen);
   GET_STR(buff, bit, len, fw_ver);


### PR DESCRIPTION
When building project with `clang-6.0.1` in `Release` mode, the compiler errors that `msg_num` and `subtype_id` are not being used, this happens because `assert` statement gets omitted and therefore there is no other usage of the variable, hence the `(void)` statements.

check: https://travis-ci.org/github/swift-nav/gnss-converters/jobs/707843874